### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,24 +17,23 @@
         "dist"
     ],
     "devDependencies": {
-        "@lwc/module-resolver": "2.5.10",
-        "@babel/plugin-syntax-decorators": "^7.17.0",
-        "@babel/preset-typescript": "^7.16.7",
-        "@types/node": "~16.11.26",
-        "babel-loader": "^8.2.4",
+        "@babel/plugin-syntax-decorators": "^7.18.6",
+        "@babel/preset-typescript": "^7.18.6",
+        "@lwc/module-resolver": "2.23.2",
+        "@types/node": "~18.7.14",
+        "babel-loader": "^8.2.5",
         "chai": "^4.3.6",
-        "lwc": "2.5.10",
-        "memfs": "^3.4.1",
-        "mocha": "^9.2.1",
-        "mocha-snap": "^4.2.4",
+        "lwc": "2.23.2",
+        "memfs": "^3.4.7",
+        "mocha": "^10.0.0",
+        "mocha-snap": "^4.3.0",
         "nyc": "^15.1.0",
-        "typescript": "~4.2.4",
-        "webpack": "~5.69.1",
+        "typescript": "~4.8.2",
+        "webpack": "~5.74.0",
         "webpack-merge": "^5.8.0"
     },
     "dependencies": {
-        "loader-utils": "^1.4.0",
-        "resolve": "~1.20.0"
+        "resolve": "^1.22.1"
     },
     "peerDependencies": {
         "@lwc/module-resolver": "^2.0.0",

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -4,15 +4,13 @@
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const { URLSearchParams } = require("url");
+const { URLSearchParams: NodeURLSearchParams } = require("url");
 const compiler = require('@lwc/compiler')
 const { getInfoFromPath } = require('./module')
-import { getOptions } from 'loader-utils'
 
-module.exports = function (source: any) {
-    const { resourcePath, resourceQuery } = this
-    const { stylesheetConfig, outputConfig, experimentalDynamicComponent } =
-        getOptions(this)
+module.exports = function loader (source: any) {
+    const { resourcePath, resourceQuery, getOptions } = this
+    const { stylesheetConfig, outputConfig, experimentalDynamicComponent } = getOptions()
 
     let info
     try {
@@ -29,7 +27,7 @@ module.exports = function (source: any) {
     // Scoped styles have paths like this: "foo.scoped.css?scoped=true"
     const scopedStyles = resourcePath.endsWith('.css') &&
         resourceQuery &&
-        new URLSearchParams(resourceQuery).get('scoped') === 'true'
+        new NodeURLSearchParams(resourceQuery).get('scoped') === 'true'
 
     const { code } = compiler.transformSync(codeTransformed, resourcePath, {
             name: info.name,

--- a/test/__snapshots__/aliases/can-import-lwc-synthetic-shadow.expected.txt
+++ b/test/__snapshots__/aliases/can-import-lwc-synthetic-shadow.expected.txt
@@ -11,7 +11,6 @@
 /**
  * Copyright (C) 2018 salesforce.com, inc.
  */
-
 /*
  * Copyright (c) 2018, salesforce.com, inc.
  * All rights reserved.
@@ -19,122 +18,79 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 function invariant(value, msg) {
-  if (!value) {
-    throw new Error(`Invariant Violation: ${msg}`);
-  }
+    if (!value) {
+        throw new Error(`Invariant Violation: ${msg}`);
+    }
 }
-
 function isTrue$1(value, msg) {
-  if (!value) {
-    throw new Error(`Assert Violation: ${msg}`);
-  }
+    if (!value) {
+        throw new Error(`Assert Violation: ${msg}`);
+    }
 }
-
 function isFalse$1(value, msg) {
-  if (value) {
-    throw new Error(`Assert Violation: ${msg}`);
-  }
+    if (value) {
+        throw new Error(`Assert Violation: ${msg}`);
+    }
 }
-
 function fail(msg) {
-  throw new Error(msg);
+    throw new Error(msg);
 }
 
 var assert = /*#__PURE__*/Object.freeze({
-  __proto__: null,
-  invariant: invariant,
-  isTrue: isTrue$1,
-  isFalse: isFalse$1,
-  fail: fail
+    __proto__: null,
+    invariant: invariant,
+    isTrue: isTrue$1,
+    isFalse: isFalse$1,
+    fail: fail
 });
+
 /*
  * Copyright (c) 2018, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
-const {
-  assign,
-  create,
-  defineProperties,
-  defineProperty,
-  freeze,
-  getOwnPropertyDescriptor,
-  getOwnPropertyNames,
-  getPrototypeOf,
-  hasOwnProperty,
-  isFrozen,
-  keys,
-  seal,
-  setPrototypeOf
-} = Object;
-const {
-  isArray
-} = Array;
-const {
-  filter: ArrayFilter,
-  find: ArrayFind,
-  indexOf: ArrayIndexOf,
-  join: ArrayJoin,
-  map: ArrayMap,
-  push: ArrayPush,
-  reduce: ArrayReduce,
-  reverse: ArrayReverse,
-  slice: ArraySlice,
-  splice: ArraySplice,
-  unshift: ArrayUnshift,
-  forEach
-} = Array.prototype;
-const {
-  charCodeAt: StringCharCodeAt,
-  replace: StringReplace,
-  slice: StringSlice,
-  toLowerCase: StringToLowerCase
-} = String.prototype;
-
+const { assign, create, defineProperties, defineProperty, freeze, getOwnPropertyDescriptor, getOwnPropertyNames, getPrototypeOf, hasOwnProperty, isFrozen, keys, seal, setPrototypeOf, } = Object;
+const { isArray } = Array;
+const { copyWithin: ArrayCopyWithin, fill: ArrayFill, filter: ArrayFilter, find: ArrayFind, indexOf: ArrayIndexOf, join: ArrayJoin, map: ArrayMap, pop: ArrayPop, push: ArrayPush, reduce: ArrayReduce, reverse: ArrayReverse, shift: ArrayShift, slice: ArraySlice, sort: ArraySort, splice: ArraySplice, unshift: ArrayUnshift, forEach, } = Array.prototype;
+const { charCodeAt: StringCharCodeAt, replace: StringReplace, slice: StringSlice, toLowerCase: StringToLowerCase, } = String.prototype;
 function isUndefined(obj) {
-  return obj === undefined;
+    return obj === undefined;
 }
-
 function isNull(obj) {
-  return obj === null;
+    return obj === null;
 }
-
 function isTrue(obj) {
-  return obj === true;
+    return obj === true;
 }
-
 function isFalse(obj) {
-  return obj === false;
+    return obj === false;
 }
-
 function isFunction(obj) {
-  return typeof obj === 'function';
+    return typeof obj === 'function';
 }
-
 function isObject(obj) {
-  return typeof obj === 'object';
+    return typeof obj === 'object';
 }
-
 const OtS = {}.toString;
-
 function toString(obj) {
-  if (obj && obj.toString) {
-    // Arrays might hold objects with "null" prototype So using
-    // Array.prototype.toString directly will cause an error Iterate through
-    // all the items and handle individually.
-    if (isArray(obj)) {
-      return ArrayJoin.call(ArrayMap.call(obj, toString), ',');
+    if (obj && obj.toString) {
+        // Arrays might hold objects with "null" prototype So using
+        // Array.prototype.toString directly will cause an error Iterate through
+        // all the items and handle individually.
+        if (isArray(obj)) {
+            return ArrayJoin.call(ArrayMap.call(obj, toString), ',');
+        }
+        return obj.toString();
     }
-
-    return obj.toString();
-  } else if (typeof obj === 'object') {
-    return OtS.call(obj);
-  } else {
-    return obj + '';
-  }
+    else if (typeof obj === 'object') {
+        return OtS.call(obj);
+    }
+    else {
+        return obj + '';
+    }
 }
+
 /*
  * Copyright (c) 2018, salesforce.com, inc.
  * All rights reserved.
@@ -142,56 +98,56 @@ function toString(obj) {
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 // Inspired from: https://mathiasbynens.be/notes/globalthis
-
-
-const _globalThis = /*@__PURE__*/function () {
-  // On recent browsers, `globalThis` is already defined. In this case return it directly.
-  if (typeof globalThis === 'object') {
-    return globalThis;
-  }
-
-  let _globalThis;
-
-  try {
-    // eslint-disable-next-line no-extend-native
-    Object.defineProperty(Object.prototype, '__magic__', {
-      get: function () {
-        return this;
-      },
-      configurable: true
-    }); // __magic__ is undefined in Safari 10 and IE10 and older.
-    // @ts-ignore
-    // eslint-disable-next-line no-undef
-
-    _globalThis = __magic__; // @ts-ignore
-
-    delete Object.prototype.__magic__;
-  } catch (ex) {// In IE8, Object.defineProperty only works on DOM objects.
-  } finally {
-    // If the magic above fails for some reason we assume that we are in a legacy browser.
-    // Assume `window` exists in this case.
-    if (typeof _globalThis === 'undefined') {
-      // @ts-ignore
-      _globalThis = window;
+const _globalThis = /*@__PURE__*/ (function () {
+    // On recent browsers, `globalThis` is already defined. In this case return it directly.
+    if (typeof globalThis === 'object') {
+        return globalThis;
     }
-  }
+    let _globalThis;
+    try {
+        // eslint-disable-next-line no-extend-native
+        Object.defineProperty(Object.prototype, '__magic__', {
+            get: function () {
+                return this;
+            },
+            configurable: true,
+        });
+        // __magic__ is undefined in Safari 10 and IE10 and older.
+        // @ts-ignore
+        // eslint-disable-next-line no-undef
+        _globalThis = __magic__;
+        // @ts-ignore
+        delete Object.prototype.__magic__;
+    }
+    catch (ex) {
+        // In IE8, Object.defineProperty only works on DOM objects.
+    }
+    finally {
+        // If the magic above fails for some reason we assume that we are in a legacy browser.
+        // Assume `window` exists in this case.
+        if (typeof _globalThis === 'undefined') {
+            // @ts-ignore
+            _globalThis = window;
+        }
+    }
+    return _globalThis;
+})();
 
-  return _globalThis;
-}();
 /*
  * Copyright (c) 2018, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
-
 const KEY__IS_NATIVE_SHADOW_ROOT_DEFINED = '$isNativeShadowRootDefined$';
 const KEY__SHADOW_RESOLVER = '$shadowResolver$';
 const KEY__SHADOW_RESOLVER_PRIVATE = '$$ShadowResolverKey$$';
+const KEY__SHADOW_STATIC = '$shadowStaticNode$';
+const KEY__SHADOW_STATIC_PRIVATE = '$shadowStaticNodeKey$';
 const KEY__SHADOW_TOKEN = '$shadowToken$';
 const KEY__SHADOW_TOKEN_PRIVATE = '$$ShadowTokenKey$$';
 const KEY__SYNTHETIC_MODE = '$$lwc-synthetic-mode';
+
 /*
  * Copyright (c) 2018, salesforce.com, inc.
  * All rights reserved.
@@ -200,10 +156,8 @@ const KEY__SYNTHETIC_MODE = '$$lwc-synthetic-mode';
  */
 // We use this to detect symbol support in order to avoid the expensive symbol polyfill. Note that
 // we can't use typeof since it will fail when transpiling.
-
-
-const hasNativeSymbolSupport = /*@__PURE__*/(() => Symbol('x').toString() === 'Symbol(x)')();
-/** version: 2.5.10 */
+const hasNativeSymbolSupport = /*@__PURE__*/ (() => Symbol('x').toString() === 'Symbol(x)')();
+/** version: 2.23.2 */
 
 /*
  * Copyright (c) 2018, salesforce.com, inc.
@@ -211,52 +165,36 @@ const hasNativeSymbolSupport = /*@__PURE__*/(() => Symbol('x').toString() === 'S
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-// eslint-disable-next-line lwc-internal/no-global-node
-
+// TODO [#2472]: Remove this workaround when appropriate.
+// eslint-disable-next-line @lwc/lwc-internal/no-global-node
 const _Node = Node;
 const nodePrototype = _Node.prototype;
-const {
-  DOCUMENT_POSITION_CONTAINED_BY,
-  DOCUMENT_POSITION_CONTAINS,
-  DOCUMENT_POSITION_PRECEDING,
-  DOCUMENT_POSITION_FOLLOWING,
-  ELEMENT_NODE,
-  TEXT_NODE,
-  CDATA_SECTION_NODE,
-  PROCESSING_INSTRUCTION_NODE,
-  COMMENT_NODE,
-  DOCUMENT_FRAGMENT_NODE
-} = _Node;
-const {
-  appendChild,
-  cloneNode,
-  compareDocumentPosition,
-  insertBefore,
-  removeChild,
-  replaceChild,
-  hasChildNodes
-} = nodePrototype;
-const {
-  contains
-} = HTMLElement.prototype;
+const { DOCUMENT_POSITION_CONTAINED_BY, DOCUMENT_POSITION_CONTAINS, DOCUMENT_POSITION_PRECEDING, DOCUMENT_POSITION_FOLLOWING, ELEMENT_NODE, TEXT_NODE, CDATA_SECTION_NODE, PROCESSING_INSTRUCTION_NODE, COMMENT_NODE, DOCUMENT_FRAGMENT_NODE, } = _Node;
+const { appendChild, cloneNode, compareDocumentPosition, insertBefore, removeChild, replaceChild, hasChildNodes, } = nodePrototype;
+const { contains } = HTMLElement.prototype;
 const firstChildGetter = getOwnPropertyDescriptor(nodePrototype, 'firstChild').get;
 const lastChildGetter = getOwnPropertyDescriptor(nodePrototype, 'lastChild').get;
 const textContentGetter = getOwnPropertyDescriptor(nodePrototype, 'textContent').get;
 const parentNodeGetter = getOwnPropertyDescriptor(nodePrototype, 'parentNode').get;
 const ownerDocumentGetter = getOwnPropertyDescriptor(nodePrototype, 'ownerDocument').get;
-const parentElementGetter = hasOwnProperty.call(nodePrototype, 'parentElement') ? getOwnPropertyDescriptor(nodePrototype, 'parentElement').get : getOwnPropertyDescriptor(HTMLElement.prototype, 'parentElement').get; // IE11
-
+const parentElementGetter = hasOwnProperty.call(nodePrototype, 'parentElement')
+    ? getOwnPropertyDescriptor(nodePrototype, 'parentElement').get
+    : getOwnPropertyDescriptor(HTMLElement.prototype, 'parentElement').get; // IE11
 const textContextSetter = getOwnPropertyDescriptor(nodePrototype, 'textContent').set;
-const childNodesGetter = hasOwnProperty.call(nodePrototype, 'childNodes') ? getOwnPropertyDescriptor(nodePrototype, 'childNodes').get : getOwnPropertyDescriptor(HTMLElement.prototype, 'childNodes').get; // IE11
-
-const isConnected = hasOwnProperty.call(nodePrototype, 'isConnected') ? getOwnPropertyDescriptor(nodePrototype, 'isConnected').get : function () {
-  const doc = ownerDocumentGetter.call(this); // IE11
-
-  return (// if doc is null, it means `this` is actually a document instance which
-    // is always connected
-    doc === null || (compareDocumentPosition.call(doc, this) & DOCUMENT_POSITION_CONTAINED_BY) !== 0
-  );
-};
+const childNodesGetter = hasOwnProperty.call(nodePrototype, 'childNodes')
+    ? getOwnPropertyDescriptor(nodePrototype, 'childNodes').get
+    : getOwnPropertyDescriptor(HTMLElement.prototype, 'childNodes').get; // IE11
+const isConnected = hasOwnProperty.call(nodePrototype, 'isConnected')
+    ? getOwnPropertyDescriptor(nodePrototype, 'isConnected').get
+    : function () {
+        const doc = ownerDocumentGetter.call(this);
+        // IE11
+        return (
+        // if doc is null, it means `this` is actually a document instance which
+        // is always connected
+        doc === null ||
+            (compareDocumentPosition.call(doc, this) & DOCUMENT_POSITION_CONTAINED_BY) !== 0);
+    };
 
 /*
  * Copyright (c) 2018, salesforce.com, inc.
@@ -264,52 +202,59 @@ const isConnected = hasOwnProperty.call(nodePrototype, 'isConnected') ? getOwnPr
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const {
-  getAttribute,
-  getBoundingClientRect,
-  getElementsByTagName: getElementsByTagName$1,
-  getElementsByTagNameNS: getElementsByTagNameNS$1,
-  hasAttribute,
-  querySelector,
-  querySelectorAll: querySelectorAll$1,
-  removeAttribute,
-  setAttribute
-} = Element.prototype;
-const attachShadow$1 = hasOwnProperty.call(Element.prototype, 'attachShadow') ? Element.prototype.attachShadow : () => {
-  throw new TypeError('attachShadow() is not supported in current browser. Load the @lwc/synthetic-shadow polyfill and use Lightning Web Components');
-};
+const { getAttribute, getBoundingClientRect, getElementsByTagName: getElementsByTagName$1, getElementsByTagNameNS: getElementsByTagNameNS$1, hasAttribute, querySelector, querySelectorAll: querySelectorAll$1, removeAttribute, setAttribute, } = Element.prototype;
+const attachShadow$1 = hasOwnProperty.call(Element.prototype, 'attachShadow')
+    ? Element.prototype.attachShadow
+    : () => {
+        throw new TypeError('attachShadow() is not supported in current browser. Load the @lwc/synthetic-shadow polyfill and use Lightning Web Components');
+    };
 const childElementCountGetter = getOwnPropertyDescriptor(Element.prototype, 'childElementCount').get;
 const firstElementChildGetter = getOwnPropertyDescriptor(Element.prototype, 'firstElementChild').get;
 const lastElementChildGetter = getOwnPropertyDescriptor(Element.prototype, 'lastElementChild').get;
 const innerTextDescriptor = getOwnPropertyDescriptor(HTMLElement.prototype, 'innerText');
-const innerTextGetter = innerTextDescriptor ? innerTextDescriptor.get : null;
-const innerTextSetter = innerTextDescriptor ? innerTextDescriptor.set : null; // Note: Firefox does not have outerText, https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/outerText
-
+const innerTextGetter = innerTextDescriptor
+    ? innerTextDescriptor.get
+    : null;
+const innerTextSetter = innerTextDescriptor
+    ? innerTextDescriptor.set
+    : null;
+// Note: Firefox does not have outerText, https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/outerText
 const outerTextDescriptor = getOwnPropertyDescriptor(HTMLElement.prototype, 'outerText');
-const outerTextGetter = outerTextDescriptor ? outerTextDescriptor.get : null;
-const outerTextSetter = outerTextDescriptor ? outerTextDescriptor.set : null;
-const innerHTMLDescriptor = hasOwnProperty.call(Element.prototype, 'innerHTML') ? getOwnPropertyDescriptor(Element.prototype, 'innerHTML') : getOwnPropertyDescriptor(HTMLElement.prototype, 'innerHTML'); // IE11
-
+const outerTextGetter = outerTextDescriptor
+    ? outerTextDescriptor.get
+    : null;
+const outerTextSetter = outerTextDescriptor
+    ? outerTextDescriptor.set
+    : null;
+const innerHTMLDescriptor = hasOwnProperty.call(Element.prototype, 'innerHTML')
+    ? getOwnPropertyDescriptor(Element.prototype, 'innerHTML')
+    : getOwnPropertyDescriptor(HTMLElement.prototype, 'innerHTML'); // IE11
 const innerHTMLGetter = innerHTMLDescriptor.get;
 const innerHTMLSetter = innerHTMLDescriptor.set;
-const outerHTMLDescriptor = hasOwnProperty.call(Element.prototype, 'outerHTML') ? getOwnPropertyDescriptor(Element.prototype, 'outerHTML') : getOwnPropertyDescriptor(HTMLElement.prototype, 'outerHTML'); // IE11
-
+const outerHTMLDescriptor = hasOwnProperty.call(Element.prototype, 'outerHTML')
+    ? getOwnPropertyDescriptor(Element.prototype, 'outerHTML')
+    : getOwnPropertyDescriptor(HTMLElement.prototype, 'outerHTML'); // IE11
 const outerHTMLGetter = outerHTMLDescriptor.get;
 const outerHTMLSetter = outerHTMLDescriptor.set;
 const tagNameGetter = getOwnPropertyDescriptor(Element.prototype, 'tagName').get;
 const tabIndexDescriptor = getOwnPropertyDescriptor(HTMLElement.prototype, 'tabIndex');
 const tabIndexGetter = tabIndexDescriptor.get;
 const tabIndexSetter = tabIndexDescriptor.set;
-const matches = hasOwnProperty.call(Element.prototype, 'matches') ? Element.prototype.matches : Element.prototype.msMatchesSelector; // IE11
-
-const childrenGetter = hasOwnProperty.call(Element.prototype, 'children') ? getOwnPropertyDescriptor(Element.prototype, 'children').get : getOwnPropertyDescriptor(HTMLElement.prototype, 'children').get; // IE11
+const matches = hasOwnProperty.call(Element.prototype, 'matches')
+    ? Element.prototype.matches
+    : Element.prototype.msMatchesSelector; // IE11
+const childrenGetter = hasOwnProperty.call(Element.prototype, 'children')
+    ? getOwnPropertyDescriptor(Element.prototype, 'children').get
+    : getOwnPropertyDescriptor(HTMLElement.prototype, 'children').get; // IE11
 // for IE11, access from HTMLElement
 // for all other browsers access the method from the parent Element interface
-
-const {
-  getElementsByClassName: getElementsByClassName$1
-} = HTMLElement.prototype;
-const shadowRootGetter = hasOwnProperty.call(Element.prototype, 'shadowRoot') ? getOwnPropertyDescriptor(Element.prototype, 'shadowRoot').get : () => null;
+const { getElementsByClassName: getElementsByClassName$1 } = HTMLElement.prototype;
+const shadowRootGetter = hasOwnProperty.call(Element.prototype, 'shadowRoot')
+    ? getOwnPropertyDescriptor(Element.prototype, 'shadowRoot').get
+    : () => null;
+const assignedSlotGetter$1 = hasOwnProperty.call(Element.prototype, 'assignedSlot')
+    ? getOwnPropertyDescriptor(Element.prototype, 'assignedSlot').get
+    : () => null;
 
 /*
  * Copyright (c) 2018, salesforce.com, inc.
@@ -318,18 +263,17 @@ const shadowRootGetter = hasOwnProperty.call(Element.prototype, 'shadowRoot') ? 
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 let assignedNodes, assignedElements;
-
 if (typeof HTMLSlotElement !== 'undefined') {
-  assignedNodes = HTMLSlotElement.prototype.assignedNodes;
-  assignedElements = HTMLSlotElement.prototype.assignedElements;
-} else {
-  assignedNodes = () => {
-    throw new TypeError("assignedNodes() is not supported in current browser. Load the @lwc/synthetic-shadow polyfill to start using <slot> elements in your Lightning Web Component's template");
-  };
-
-  assignedElements = () => {
-    throw new TypeError("assignedElements() is not supported in current browser. Load the @lwc/synthetic-shadow polyfill to start using <slot> elements in your Lightning Web Component's template");
-  };
+    assignedNodes = HTMLSlotElement.prototype.assignedNodes;
+    assignedElements = HTMLSlotElement.prototype.assignedElements;
+}
+else {
+    assignedNodes = () => {
+        throw new TypeError("assignedNodes() is not supported in current browser. Load the @lwc/synthetic-shadow polyfill to start using <slot> elements in your Lightning Web Component's template");
+    };
+    assignedElements = () => {
+        throw new TypeError("assignedElements() is not supported in current browser. Load the @lwc/synthetic-shadow polyfill to start using <slot> elements in your Lightning Web Component's template");
+    };
 }
 
 /*
@@ -340,11 +284,13 @@ if (typeof HTMLSlotElement !== 'undefined') {
  */
 const eventTargetGetter = getOwnPropertyDescriptor(Event.prototype, 'target').get;
 const eventCurrentTargetGetter = getOwnPropertyDescriptor(Event.prototype, 'currentTarget').get;
-const focusEventRelatedTargetGetter = getOwnPropertyDescriptor(FocusEvent.prototype, 'relatedTarget').get; // IE does not implement composedPath() but that's ok because we only use this instead of our
+const focusEventRelatedTargetGetter = getOwnPropertyDescriptor(FocusEvent.prototype, 'relatedTarget').get;
+// IE does not implement composedPath() but that's ok because we only use this instead of our
 // composedPath() polyfill when dealing with native shadow DOM components in mixed mode. Defaulting
 // to a NOOP just to be safe, even though this is almost guaranteed to be defined such a scenario.
-
-const composedPath = hasOwnProperty.call(Event.prototype, 'composedPath') ? Event.prototype.composedPath : () => [];
+const composedPath = hasOwnProperty.call(Event.prototype, 'composedPath')
+    ? Event.prototype.composedPath
+    : () => [];
 
 /*
  * Copyright (c) 2018, salesforce.com, inc.
@@ -353,26 +299,19 @@ const composedPath = hasOwnProperty.call(Event.prototype, 'composedPath') ? Even
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const DocumentPrototypeActiveElement = getOwnPropertyDescriptor(Document.prototype, 'activeElement').get;
-const elementFromPoint = hasOwnProperty.call(Document.prototype, 'elementFromPoint') ? Document.prototype.elementFromPoint : Document.prototype.msElementFromPoint; // IE11
-
-const elementsFromPoint = hasOwnProperty.call(Document.prototype, 'elementsFromPoint') ? Document.prototype.elementsFromPoint : Document.prototype.msElementsFromPoint; // IE11
+const elementFromPoint = hasOwnProperty.call(Document.prototype, 'elementFromPoint')
+    ? Document.prototype.elementFromPoint
+    : Document.prototype.msElementFromPoint; // IE11
+const elementsFromPoint = hasOwnProperty.call(Document.prototype, 'elementsFromPoint')
+    ? Document.prototype.elementsFromPoint
+    : Document.prototype.msElementsFromPoint; // IE11
 // defaultView can be null when a document has no browsing context. For example, the owner document
 // of a node in a template doesn't have a default view: https://jsfiddle.net/hv9z0q5a/
-
 const defaultViewGetter = getOwnPropertyDescriptor(Document.prototype, 'defaultView').get;
-const {
-  createComment,
-  querySelectorAll,
-  getElementById,
-  getElementsByClassName,
-  getElementsByTagName,
-  getElementsByTagNameNS
-} = Document.prototype; // In Firefox v57 and lower, getElementsByName is defined on HTMLDocument.prototype
+const { createComment, querySelectorAll, getElementById, getElementsByClassName, getElementsByTagName, getElementsByTagNameNS, } = Document.prototype;
+// In Firefox v57 and lower, getElementsByName is defined on HTMLDocument.prototype
 // In all other browsers have the method on Document.prototype
-
-const {
-  getElementsByName
-} = HTMLDocument.prototype;
+const { getElementsByName } = HTMLDocument.prototype;
 
 /*
  * Copyright (c) 2018, salesforce.com, inc.
@@ -380,12 +319,7 @@ const {
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const {
-  addEventListener: windowAddEventListener,
-  removeEventListener: windowRemoveEventListener,
-  getComputedStyle: windowGetComputedStyle,
-  getSelection: windowGetSelection
-} = window;
+const { addEventListener: windowAddEventListener, removeEventListener: windowRemoveEventListener, getComputedStyle: windowGetComputedStyle, getSelection: windowGetSelection, } = window;
 
 /*
  * Copyright (c) 2018, salesforce.com, inc.
@@ -406,13 +340,13 @@ const MutationObserverObserve = MO.prototype.observe;
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 let NativeShadowRoot = null;
-
 if (typeof ShadowRoot !== 'undefined') {
-  NativeShadowRoot = ShadowRoot;
+    NativeShadowRoot = ShadowRoot;
 }
-
 const isNativeShadowRootDefined = !isNull(NativeShadowRoot);
-const isInstanceOfNativeShadowRoot = isNull(NativeShadowRoot) ? () => false : node => node instanceof NativeShadowRoot;
+const isInstanceOfNativeShadowRoot = isNull(NativeShadowRoot)
+    ? () => false
+    : (node) => node instanceof NativeShadowRoot;
 
 /*
  * Copyright (c) 2018, salesforce.com, inc.
@@ -421,7 +355,7 @@ const isInstanceOfNativeShadowRoot = isNull(NativeShadowRoot) ? () => false : no
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 function detect$4 () {
-  return typeof HTMLSlotElement === 'undefined';
+    return typeof HTMLSlotElement === 'undefined';
 }
 
 /*
@@ -430,38 +364,38 @@ function detect$4 () {
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const {
-  createElement
-} = Document.prototype;
+const { createElement } = Document.prototype;
 const CHAR_S = 115;
 const CHAR_L = 108;
 const CHAR_O = 111;
 const CHAR_T = 116;
 function apply$4() {
-  // IE11 does not have this element definition
-  // we don't care much about the construction phase, just the prototype
-  class HTMLSlotElement {} // prototype inheritance dance
-
-
-  setPrototypeOf(HTMLSlotElement, HTMLElement.constructor);
-  setPrototypeOf(HTMLSlotElement.prototype, HTMLElement.prototype);
-  Window.prototype.HTMLSlotElement = HTMLSlotElement; // IE11 doesn't have HTMLSlotElement, in which case we
-  // need to patch Document.prototype.createElement to remap `slot`
-  // elements to the right prototype
-
-  defineProperty(Document.prototype, 'createElement', {
-    value: function (tagName, _options) {
-      const elm = createElement.apply(this, ArraySlice.call(arguments));
-
-      if (tagName.length === 4 && StringCharCodeAt.call(tagName, 0) === CHAR_S && StringCharCodeAt.call(tagName, 1) === CHAR_L && StringCharCodeAt.call(tagName, 2) === CHAR_O && StringCharCodeAt.call(tagName, 3) === CHAR_T) {
-        // the new element is the `slot`, resetting the proto chain
-        // the new newly created global HTMLSlotElement.prototype
-        setPrototypeOf(elm, HTMLSlotElement.prototype);
-      }
-
-      return elm;
+    // IE11 does not have this element definition
+    // we don't care much about the construction phase, just the prototype
+    class HTMLSlotElement {
     }
-  });
+    // prototype inheritance dance
+    setPrototypeOf(HTMLSlotElement, HTMLElement.constructor);
+    setPrototypeOf(HTMLSlotElement.prototype, HTMLElement.prototype);
+    Window.prototype.HTMLSlotElement = HTMLSlotElement;
+    // IE11 doesn't have HTMLSlotElement, in which case we
+    // need to patch Document.prototype.createElement to remap `slot`
+    // elements to the right prototype
+    defineProperty(Document.prototype, 'createElement', {
+        value: function (tagName, _options) {
+            const elm = createElement.apply(this, ArraySlice.call(arguments));
+            if (tagName.length === 4 &&
+                StringCharCodeAt.call(tagName, 0) === CHAR_S &&
+                StringCharCodeAt.call(tagName, 1) === CHAR_L &&
+                StringCharCodeAt.call(tagName, 2) === CHAR_O &&
+                StringCharCodeAt.call(tagName, 3) === CHAR_T) {
+                // the new element is the `slot`, resetting the proto chain
+                // the new newly created global HTMLSlotElement.prototype
+                setPrototypeOf(elm, HTMLSlotElement.prototype);
+            }
+            return elm;
+        },
+    });
 }
 
 /*
@@ -470,9 +404,8 @@ function apply$4() {
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
 if (detect$4()) {
-  apply$4();
+    apply$4();
 }
 
 /*
@@ -481,61 +414,46 @@ if (detect$4()) {
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
+// Helpful for tests running with jsdom
 function getOwnerDocument(node) {
-  const doc = ownerDocumentGetter.call(node); // if doc is null, it means `this` is actually a document instance
-
-  return doc === null ? node : doc;
+    const doc = ownerDocumentGetter.call(node);
+    // if doc is null, it means `this` is actually a document instance
+    return doc === null ? node : doc;
 }
 function getOwnerWindow(node) {
-  const doc = getOwnerDocument(node);
-  const win = defaultViewGetter.call(doc);
-
-  if (win === null) {
-    // this method should never be called with a node that is not part
-    // of a qualifying connected node.
-    throw new TypeError();
-  }
-
-  return win;
+    const doc = getOwnerDocument(node);
+    const win = defaultViewGetter.call(doc);
+    if (win === null) {
+        // this method should never be called with a node that is not part
+        // of a qualifying connected node.
+        throw new TypeError();
+    }
+    return win;
 }
-let skipGlobalPatching; // TODO [#1222]: remove global bypass
-
+let skipGlobalPatching;
+// TODO [#1222]: remove global bypass
 function isGlobalPatchingSkipped(node) {
-  // we lazily compute this value instead of doing it during evaluation, this helps
-  // for apps that are setting this after the engine code is evaluated.
-  if (isUndefined(skipGlobalPatching)) {
-    const ownerDocument = getOwnerDocument(node);
-    skipGlobalPatching = ownerDocument.body && getAttribute.call(ownerDocument.body, 'data-global-patching-bypass') === 'temporary-bypass';
-  }
-
-  return isTrue(skipGlobalPatching);
+    // we lazily compute this value instead of doing it during evaluation, this helps
+    // for apps that are setting this after the engine code is evaluated.
+    if (isUndefined(skipGlobalPatching)) {
+        const ownerDocument = getOwnerDocument(node);
+        skipGlobalPatching =
+            ownerDocument.body &&
+                getAttribute.call(ownerDocument.body, 'data-global-patching-bypass') ===
+                    'temporary-bypass';
+    }
+    return isTrue(skipGlobalPatching);
 }
 function arrayFromCollection(collection) {
-  const size = collection.length;
-  const cloned = [];
-
-  if (size > 0) {
-    for (let i = 0; i < size; i++) {
-      cloned[i] = collection[i];
+    const size = collection.length;
+    const cloned = [];
+    if (size > 0) {
+        for (let i = 0; i < size; i++) {
+            cloned[i] = collection[i];
+        }
     }
-  }
-
-  return cloned;
+    return cloned;
 }
-
-/**
- * Copyright (C) 2018 salesforce.com, inc.
- */
-
-if (!_globalThis.lwcRuntimeFlags) {
-  Object.defineProperty(_globalThis, 'lwcRuntimeFlags', {
-    value: create(null)
-  });
-}
-
-const runtimeFlags = _globalThis.lwcRuntimeFlags;
-/** version: 2.5.10 */
 
 /*
  * Copyright (c) 2018, salesforce.com, inc.
@@ -544,11 +462,7 @@ const runtimeFlags = _globalThis.lwcRuntimeFlags;
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const eventTargetPrototype = typeof EventTarget !== 'undefined' ? EventTarget.prototype : _Node.prototype;
-const {
-  addEventListener,
-  dispatchEvent,
-  removeEventListener
-} = eventTargetPrototype;
+const { addEventListener, dispatchEvent, removeEventListener } = eventTargetPrototype;
 
 /*
  * Copyright (c) 2018, salesforce.com, inc.
@@ -556,471 +470,48 @@ const {
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const EventListenerMap = new WeakMap();
-const ComposedPathMap = new WeakMap();
-
-function isEventListenerOrEventListenerObject(fnOrObj) {
-  return isFunction(fnOrObj) || isObject(fnOrObj) && !isNull(fnOrObj) && isFunction(fnOrObj.handleEvent);
-}
-
-function shouldInvokeListener(event, target, currentTarget) {
-  // Subsequent logic assumes that `currentTarget` must be contained in the composed path for the listener to be
-  // invoked, but this is not always the case. `composedPath()` will sometimes return an empty array, even when the
-  // listener should be invoked (e.g., a disconnected instance of EventTarget, an instance of XMLHttpRequest, etc).
-  if (target === currentTarget) {
-    return true;
-  }
-
-  let composedPath = ComposedPathMap.get(event);
-
-  if (isUndefined(composedPath)) {
-    composedPath = event.composedPath();
-    ComposedPathMap.set(event, composedPath);
-  }
-
-  return composedPath.includes(currentTarget);
-}
-function getEventListenerWrapper(fnOrObj) {
-  if (!isEventListenerOrEventListenerObject(fnOrObj)) {
-    return fnOrObj;
-  }
-
-  let wrapperFn = EventListenerMap.get(fnOrObj);
-
-  if (isUndefined(wrapperFn)) {
-    wrapperFn = function (event) {
-      // This function is invoked from an event listener and currentTarget is always defined.
-      const currentTarget = eventCurrentTargetGetter.call(event);
-
-      if (true) {
-        assert.invariant(isFalse(isSyntheticShadowHost(currentTarget)), 'This routine should not be used to wrap event listeners for host elements and shadow roots.');
-      }
-
-      const {
-        composed
-      } = event;
-      let shouldInvoke;
-
-      if (runtimeFlags.ENABLE_NON_COMPOSED_EVENTS_LEAKAGE) {
-        shouldInvoke = !(eventToShadowRootMap.has(event) && isFalse(composed));
-      } else {
-        const actualTarget = getActualTarget(event);
-        shouldInvoke = shouldInvokeListener(event, actualTarget, currentTarget);
-      }
-
-      if (!shouldInvoke) {
-        return;
-      }
-
-      return isFunction(fnOrObj) ? fnOrObj.call(this, event) : fnOrObj.handleEvent && fnOrObj.handleEvent(event);
-    };
-
-    EventListenerMap.set(fnOrObj, wrapperFn);
-  }
-
-  return wrapperFn;
-}
-
-/*
- * Copyright (c) 2018, salesforce.com, inc.
- * All rights reserved.
- * SPDX-License-Identifier: MIT
- * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
- */
-const eventToContextMap = new WeakMap();
-
-function isChildNode(root, node) {
-  return !!(compareDocumentPosition.call(root, node) & DOCUMENT_POSITION_CONTAINED_BY);
-}
-
-const GET_ROOT_NODE_CONFIG_FALSE = {
-  composed: false
-};
-
-function getRootNodeHost(node, options) {
-  let rootNode = node.getRootNode(options);
-
-  if (isSyntheticShadowRoot(rootNode)) {
-    rootNode = getHost(rootNode);
-  }
-
-  return rootNode;
-}
-
-const customElementToWrappedListeners = new WeakMap();
-
-function getEventMap(elm) {
-  let listenerInfo = customElementToWrappedListeners.get(elm);
-
-  if (isUndefined(listenerInfo)) {
-    listenerInfo = create(null);
-    customElementToWrappedListeners.set(elm, listenerInfo);
-  }
-
-  return listenerInfo;
-}
-/**
- * Events dispatched on shadow roots actually end up being dispatched on their hosts. This means that the event.target
- * property of events dispatched on shadow roots always resolve to their host. This function understands this
- * abstraction and properly returns a reference to the shadow root when appropriate.
- */
-
-
-function getActualTarget(event) {
-  var _a;
-
-  return (_a = eventToShadowRootMap.get(event)) !== null && _a !== void 0 ? _a : eventTargetGetter.call(event);
-}
-const shadowRootEventListenerMap = new WeakMap();
-
-function getWrappedShadowRootListener(listener) {
-  if (!isFunction(listener)) {
-    throw new TypeError(); // avoiding problems with non-valid listeners
-  }
-
-  let shadowRootWrappedListener = shadowRootEventListenerMap.get(listener);
-
-  if (isUndefined(shadowRootWrappedListener)) {
-    shadowRootWrappedListener = function (event) {
-      // currentTarget is always defined inside an event listener
-      let currentTarget = eventCurrentTargetGetter.call(event); // If currentTarget is not an instance of a native shadow root then we're dealing with a
-      // host element whose synthetic shadow root must be accessed via getShadowRoot().
-
-      if (!isInstanceOfNativeShadowRoot(currentTarget)) {
-        currentTarget = getShadowRoot(currentTarget);
-      }
-
-      let shouldInvoke;
-
-      if (runtimeFlags.ENABLE_NON_COMPOSED_EVENTS_LEAKAGE) {
-        shouldInvoke = shouldInvokeShadowRootListener(event);
-      } else {
-        const actualTarget = getActualTarget(event);
-        shouldInvoke = shouldInvokeListener(event, actualTarget, currentTarget);
-      }
-
-      if (shouldInvoke) {
-        listener.call(currentTarget, event);
-      }
-    };
-
-    shadowRootWrappedListener.placement = 1
-    /* SHADOW_ROOT_LISTENER */
-    ;
-    shadowRootEventListenerMap.set(listener, shadowRootWrappedListener);
-  }
-
-  return shadowRootWrappedListener;
-}
-
-const customElementEventListenerMap = new WeakMap();
-
-function getWrappedCustomElementListener(listener) {
-  if (!isFunction(listener)) {
-    throw new TypeError(); // avoiding problems with non-valid listeners
-  }
-
-  let customElementWrappedListener = customElementEventListenerMap.get(listener);
-
-  if (isUndefined(customElementWrappedListener)) {
-    customElementWrappedListener = function (event) {
-      // currentTarget is always defined inside an event listener
-      const currentTarget = eventCurrentTargetGetter.call(event);
-      let shouldInvoke;
-
-      if (runtimeFlags.ENABLE_NON_COMPOSED_EVENTS_LEAKAGE) {
-        shouldInvoke = shouldInvokeCustomElementListener(event);
-      } else {
-        const actualTarget = getActualTarget(event);
-        shouldInvoke = shouldInvokeListener(event, actualTarget, currentTarget);
-      }
-
-      if (shouldInvoke) {
-        listener.call(currentTarget, event);
-      }
-    };
-
-    customElementWrappedListener.placement = 0
-    /* CUSTOM_ELEMENT_LISTENER */
-    ;
-    customElementEventListenerMap.set(listener, customElementWrappedListener);
-  }
-
-  return customElementWrappedListener;
-}
-
-function domListener(evt) {
-  let immediatePropagationStopped = false;
-  let propagationStopped = false;
-  const {
-    type,
-    stopImmediatePropagation,
-    stopPropagation
-  } = evt; // currentTarget is always defined
-
-  const currentTarget = eventCurrentTargetGetter.call(evt);
-  const listenerMap = getEventMap(currentTarget);
-  const listeners = listenerMap[type]; // it must have listeners at this point
-
-  defineProperty(evt, 'stopImmediatePropagation', {
-    value() {
-      immediatePropagationStopped = true;
-      stopImmediatePropagation.call(evt);
-    },
-
-    writable: true,
-    enumerable: true,
-    configurable: true
-  });
-  defineProperty(evt, 'stopPropagation', {
-    value() {
-      propagationStopped = true;
-      stopPropagation.call(evt);
-    },
-
-    writable: true,
-    enumerable: true,
-    configurable: true
-  }); // in case a listener adds or removes other listeners during invocation
-
-  const bookkeeping = ArraySlice.call(listeners);
-
-  function invokeListenersByPlacement(placement) {
-    forEach.call(bookkeeping, listener => {
-      if (isFalse(immediatePropagationStopped) && listener.placement === placement) {
-        // making sure that the listener was not removed from the original listener queue
-        if (ArrayIndexOf.call(listeners, listener) !== -1) {
-          // all handlers on the custom element should be called with undefined 'this'
-          listener.call(undefined, evt);
-        }
-      }
-    });
-  }
-
-  eventToContextMap.set(evt, 1
-  /* SHADOW_ROOT_LISTENER */
-  );
-  invokeListenersByPlacement(1
-  /* SHADOW_ROOT_LISTENER */
-  );
-
-  if (isFalse(immediatePropagationStopped) && isFalse(propagationStopped)) {
-    // doing the second iteration only if the first one didn't interrupt the event propagation
-    eventToContextMap.set(evt, 0
-    /* CUSTOM_ELEMENT_LISTENER */
-    );
-    invokeListenersByPlacement(0
-    /* CUSTOM_ELEMENT_LISTENER */
-    );
-  }
-
-  eventToContextMap.set(evt, 2
-  /* UNKNOWN_LISTENER */
-  );
-}
-
-function attachDOMListener(elm, type, wrappedListener) {
-  const listenerMap = getEventMap(elm);
-  let cmpEventHandlers = listenerMap[type];
-
-  if (isUndefined(cmpEventHandlers)) {
-    cmpEventHandlers = listenerMap[type] = [];
-  } // Prevent identical listeners from subscribing to the same event type.
-  // TODO [#1824]: Options will also play a factor when we introduce support for them (#1824).
-
-
-  if (ArrayIndexOf.call(cmpEventHandlers, wrappedListener) !== -1) {
-    return;
-  } // only add to DOM if there is no other listener on the same placement yet
-
-
-  if (cmpEventHandlers.length === 0) {
-    // super.addEventListener() - this will not work on
-    addEventListener.call(elm, type, domListener);
-  }
-
-  ArrayPush.call(cmpEventHandlers, wrappedListener);
-}
-
-function detachDOMListener(elm, type, wrappedListener) {
-  const listenerMap = getEventMap(elm);
-  let p;
-  let listeners;
-
-  if (!isUndefined(listeners = listenerMap[type]) && (p = ArrayIndexOf.call(listeners, wrappedListener)) !== -1) {
-    ArraySplice.call(listeners, p, 1); // only remove from DOM if there is no other listener on the same placement
-
-    if (listeners.length === 0) {
-      removeEventListener.call(elm, type, domListener);
-    }
-  }
-}
-
-function shouldInvokeCustomElementListener(event) {
-  const {
-    composed
-  } = event;
-
-  if (isTrue(composed)) {
-    // Listeners on host elements should always be invoked for {composed: true} events.
-    return true;
-  } // If this {composed: false} event was dispatched on any root.
-
-
-  if (eventToShadowRootMap.has(event)) {
-    return false;
-  }
-
-  const target = eventTargetGetter.call(event);
-  const currentTarget = eventCurrentTargetGetter.call(event); // If this {composed: false} event was dispatched on the current target host.
-
-  if (target === currentTarget) {
-    return true;
-  } // At this point the event must be {bubbles: true, composed: false} and was dispatched from a
-  // shadow-excluding descendant node. In this case, we only invoke the listener if the target
-  // host was assigned to a slot in the composed subtree of the current target host.
-
-
-  const targetHost = getRootNodeHost(target, GET_ROOT_NODE_CONFIG_FALSE);
-  const currentTargetHost = currentTarget;
-  return isChildNode(targetHost, currentTargetHost);
-}
-
-function shouldInvokeShadowRootListener(event) {
-  const {
-    composed
-  } = event;
-  const target = eventTargetGetter.call(event);
-  const currentTarget = eventCurrentTargetGetter.call(event); // If the event was dispatched on the host or its root.
-
-  if (target === currentTarget) {
-    // Invoke the listener if the event was dispatched directly on the root.
-    return eventToShadowRootMap.get(event) === getShadowRoot(target);
-  } // At this point the event is {bubbles: true} and was dispatched from a shadow-including descendant node.
-
-
-  if (isTrue(composed)) {
-    // Invoke the listener if the event is {composed: true}.
-    return true;
-  } // At this point the event must be {bubbles: true, composed: false}.
-
-
-  if (isTrue(eventToShadowRootMap.has(event))) {
-    // Don't invoke the listener because the event was dispatched on a descendant root.
-    return false;
-  }
-
-  const targetHost = getRootNodeHost(target, GET_ROOT_NODE_CONFIG_FALSE);
-  const currentTargetHost = currentTarget;
-  const isCurrentTargetSlotted = isChildNode(targetHost, currentTargetHost); // At this point the event must be {bubbles: true, composed: false} and was dispatched from a
-  // shadow-excluding descendant node. In this case, we only invoke the listener if the target
-  // host was assigned to a slot in the composed subtree of the current target host, or the
-  // descendant node is in the shadow tree of the current root.
-
-  return isCurrentTargetSlotted || targetHost === currentTargetHost;
-}
-
-function addCustomElementEventListener(type, listener, _options) {
-  if (true) {
-    if (!isFunction(listener)) {
-      throw new TypeError(`Invalid second argument for Element.addEventListener() in ${toString(this)} for event "${type}". Expected an EventListener but received ${listener}.`);
-    }
-  } // TODO [#1824]: Lift this restriction on the option parameter
-
-
-  if (isFunction(listener)) {
-    const wrappedListener = getWrappedCustomElementListener(listener);
-    attachDOMListener(this, type, wrappedListener);
-  }
-}
-function removeCustomElementEventListener(type, listener, _options) {
-  // TODO [#1824]: Lift this restriction on the option parameter
-  if (isFunction(listener)) {
-    const wrappedListener = getWrappedCustomElementListener(listener);
-    detachDOMListener(this, type, wrappedListener);
-  }
-}
-function addShadowRootEventListener(sr, type, listener, _options) {
-  if (true) {
-    if (!isFunction(listener)) {
-      throw new TypeError(`Invalid second argument for ShadowRoot.addEventListener() in ${toString(sr)} for event "${type}". Expected an EventListener but received ${listener}.`);
-    }
-  } // TODO [#1824]: Lift this restriction on the option parameter
-
-
-  if (isFunction(listener)) {
-    const elm = getHost(sr);
-    const wrappedListener = getWrappedShadowRootListener(listener);
-    attachDOMListener(elm, type, wrappedListener);
-  }
-}
-function removeShadowRootEventListener(sr, type, listener, _options) {
-  // TODO [#1824]: Lift this restriction on the option parameter
-  if (isFunction(listener)) {
-    const elm = getHost(sr);
-    const wrappedListener = getWrappedShadowRootListener(listener);
-    detachDOMListener(elm, type, wrappedListener);
-  }
-}
-
-/*
- * Copyright (c) 2018, salesforce.com, inc.
- * All rights reserved.
- * SPDX-License-Identifier: MIT
- * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
- */
-
+// Used as a back reference to identify the host element
 const HostElementKey = '$$HostElementKey$$';
 const ShadowedNodeKey = '$$ShadowedNodeKey$$';
-
 function fastDefineProperty(node, propName, config) {
-  const shadowedNode = node;
-
-  if (true) {
-    // in dev, we are more restrictive
-    defineProperty(shadowedNode, propName, config);
-  } else {}
+    const shadowedNode = node;
+    if (true) {
+        // in dev, we are more restrictive
+        defineProperty(shadowedNode, propName, config);
+    }
+    else {}
 }
-
 function setNodeOwnerKey(node, value) {
-  fastDefineProperty(node, HostElementKey, {
-    value,
-    configurable: true
-  });
+    fastDefineProperty(node, HostElementKey, { value, configurable: true });
 }
 function setNodeKey(node, value) {
-  fastDefineProperty(node, ShadowedNodeKey, {
-    value
-  });
+    fastDefineProperty(node, ShadowedNodeKey, { value });
 }
 function getNodeOwnerKey(node) {
-  return node[HostElementKey];
+    return node[HostElementKey];
 }
 function getNodeNearestOwnerKey(node) {
-  let host = node;
-  let hostKey; // search for the first element with owner identity (just in case of manually inserted elements)
-
-  while (!isNull(host)) {
-    hostKey = getNodeOwnerKey(host);
-
-    if (!isUndefined(hostKey)) {
-      return hostKey;
+    let host = node;
+    let hostKey;
+    // search for the first element with owner identity (just in case of manually inserted elements)
+    while (!isNull(host)) {
+        hostKey = getNodeOwnerKey(host);
+        if (!isUndefined(hostKey)) {
+            return hostKey;
+        }
+        host = parentNodeGetter.call(host);
     }
-
-    host = parentNodeGetter.call(host);
-  }
 }
 function getNodeKey(node) {
-  return node[ShadowedNodeKey];
+    return node[ShadowedNodeKey];
 }
 /**
  * This function does not traverse up for performance reasons, but is sufficient for most use
  * cases. If we need to traverse up and verify those nodes that don't have owner key, use
  * isNodeDeepShadowed instead.
  */
-
 function isNodeShadowed(node) {
-  return !isUndefined(getNodeOwnerKey(node));
+    return !isUndefined(getNodeOwnerKey(node));
 }
 
 /*
@@ -1029,484 +520,201 @@ function isNodeShadowed(node) {
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+// when finding a slot in the DOM, we can fold it if it is contained
 // inside another slot.
-
 function foldSlotElement(slot) {
-  let parent = parentElementGetter.call(slot);
-
-  while (!isNull(parent) && isSlotElement(parent)) {
-    slot = parent;
-    parent = parentElementGetter.call(slot);
-  }
-
-  return slot;
-}
-
-function isNodeSlotted(host, node) {
-  if (true) {
-    assert.invariant(host instanceof HTMLElement, `isNodeSlotted() should be called with a host as the first argument instead of ${host}`);
-    assert.invariant(node instanceof _Node, `isNodeSlotted() should be called with a node as the second argument instead of ${node}`);
-    assert.invariant(compareDocumentPosition.call(node, host) & DOCUMENT_POSITION_CONTAINS, `isNodeSlotted() should never be called with a node that is not a child node of ${host}`);
-  }
-
-  const hostKey = getNodeKey(host); // this routine assumes that the node is coming from a different shadow (it is not owned by the host)
-  // just in case the provided node is not an element
-
-  let currentElement = node instanceof Element ? node : parentElementGetter.call(node);
-
-  while (!isNull(currentElement) && currentElement !== host) {
-    const elmOwnerKey = getNodeNearestOwnerKey(currentElement);
-    const parent = parentElementGetter.call(currentElement);
-
-    if (elmOwnerKey === hostKey) {
-      // we have reached an element inside the host's template, and only if
-      // that element is an slot, then the node is considered slotted
-      return isSlotElement(currentElement);
-    } else if (parent === host) {
-      return false;
-    } else if (!isNull(parent) && getNodeNearestOwnerKey(parent) !== elmOwnerKey) {
-      // we are crossing a boundary of some sort since the elm and its parent
-      // have different owner key. for slotted elements, this is possible
-      // if the parent happens to be a slot.
-      if (isSlotElement(parent)) {
-        /**
-         * the slot parent might be allocated inside another slot, think of:
-         * <x-root> (<--- root element)
-         *    <x-parent> (<--- own by x-root)
-         *       <x-child> (<--- own by x-root)
-         *           <slot> (<--- own by x-child)
-         *               <slot> (<--- own by x-parent)
-         *                  <div> (<--- own by x-root)
-         *
-         * while checking if x-parent has the div slotted, we need to traverse
-         * up, but when finding the first slot, we skip that one in favor of the
-         * most outer slot parent before jumping into its corresponding host.
-         */
-        currentElement = getNodeOwner(foldSlotElement(parent));
-
-        if (!isNull(currentElement)) {
-          if (currentElement === host) {
-            // the slot element is a top level element inside the shadow
-            // of a host that was allocated into host in question
-            return true;
-          } else if (getNodeNearestOwnerKey(currentElement) === hostKey) {
-            // the slot element is an element inside the shadow
-            // of a host that was allocated into host in question
-            return true;
-          }
-        }
-      } else {
-        return false;
-      }
-    } else {
-      currentElement = parent;
+    let parent = parentElementGetter.call(slot);
+    while (!isNull(parent) && isSlotElement(parent)) {
+        slot = parent;
+        parent = parentElementGetter.call(slot);
     }
-  }
-
-  return false;
+    return slot;
 }
-
+function isNodeSlotted(host, node) {
+    if (true) {
+        assert.invariant(host instanceof HTMLElement, `isNodeSlotted() should be called with a host as the first argument instead of ${host}`);
+        assert.invariant(node instanceof _Node, `isNodeSlotted() should be called with a node as the second argument instead of ${node}`);
+        assert.invariant(compareDocumentPosition.call(node, host) & DOCUMENT_POSITION_CONTAINS, `isNodeSlotted() should never be called with a node that is not a child node of ${host}`);
+    }
+    const hostKey = getNodeKey(host);
+    // this routine assumes that the node is coming from a different shadow (it is not owned by the host)
+    // just in case the provided node is not an element
+    let currentElement = node instanceof Element ? node : parentElementGetter.call(node);
+    while (!isNull(currentElement) && currentElement !== host) {
+        const elmOwnerKey = getNodeNearestOwnerKey(currentElement);
+        const parent = parentElementGetter.call(currentElement);
+        if (elmOwnerKey === hostKey) {
+            // we have reached an element inside the host's template, and only if
+            // that element is an slot, then the node is considered slotted
+            return isSlotElement(currentElement);
+        }
+        else if (parent === host) {
+            return false;
+        }
+        else if (!isNull(parent) && getNodeNearestOwnerKey(parent) !== elmOwnerKey) {
+            // we are crossing a boundary of some sort since the elm and its parent
+            // have different owner key. for slotted elements, this is possible
+            // if the parent happens to be a slot.
+            if (isSlotElement(parent)) {
+                /**
+                 * the slot parent might be allocated inside another slot, think of:
+                 * <x-root> (<--- root element)
+                 *    <x-parent> (<--- own by x-root)
+                 *       <x-child> (<--- own by x-root)
+                 *           <slot> (<--- own by x-child)
+                 *               <slot> (<--- own by x-parent)
+                 *                  <div> (<--- own by x-root)
+                 *
+                 * while checking if x-parent has the div slotted, we need to traverse
+                 * up, but when finding the first slot, we skip that one in favor of the
+                 * most outer slot parent before jumping into its corresponding host.
+                 */
+                currentElement = getNodeOwner(foldSlotElement(parent));
+                if (!isNull(currentElement)) {
+                    if (currentElement === host) {
+                        // the slot element is a top level element inside the shadow
+                        // of a host that was allocated into host in question
+                        return true;
+                    }
+                    else if (getNodeNearestOwnerKey(currentElement) === hostKey) {
+                        // the slot element is an element inside the shadow
+                        // of a host that was allocated into host in question
+                        return true;
+                    }
+                }
+            }
+            else {
+                return false;
+            }
+        }
+        else {
+            currentElement = parent;
+        }
+    }
+    return false;
+}
 function getNodeOwner(node) {
-  if (!(node instanceof _Node)) {
-    return null;
-  }
-
-  const ownerKey = getNodeNearestOwnerKey(node);
-
-  if (isUndefined(ownerKey)) {
-    return null;
-  }
-
-  let nodeOwner = node; // At this point, node is a valid node with owner identity, now we need to find the owner node
-  // search for a custom element with a VM that owns the first element with owner identity attached to it
-
-  while (!isNull(nodeOwner) && getNodeKey(nodeOwner) !== ownerKey) {
-    nodeOwner = parentNodeGetter.call(nodeOwner);
-  }
-
-  if (isNull(nodeOwner)) {
-    return null;
-  }
-
-  return nodeOwner;
+    if (!(node instanceof _Node)) {
+        return null;
+    }
+    const ownerKey = getNodeNearestOwnerKey(node);
+    if (isUndefined(ownerKey)) {
+        return null;
+    }
+    let nodeOwner = node;
+    // At this point, node is a valid node with owner identity, now we need to find the owner node
+    // search for a custom element with a VM that owns the first element with owner identity attached to it
+    while (!isNull(nodeOwner) && getNodeKey(nodeOwner) !== ownerKey) {
+        nodeOwner = parentNodeGetter.call(nodeOwner);
+    }
+    if (isNull(nodeOwner)) {
+        return null;
+    }
+    return nodeOwner;
 }
 function isSyntheticSlotElement(node) {
-  return isSlotElement(node) && isNodeShadowed(node);
+    return isSlotElement(node) && isNodeShadowed(node);
 }
 function isSlotElement(node) {
-  return node instanceof HTMLSlotElement;
+    return node instanceof HTMLSlotElement;
 }
 function isNodeOwnedBy(owner, node) {
-  if (true) {
-    assert.invariant(owner instanceof HTMLElement, `isNodeOwnedBy() should be called with an element as the first argument instead of ${owner}`);
-    assert.invariant(node instanceof _Node, `isNodeOwnedBy() should be called with a node as the second argument instead of ${node}`);
-    assert.invariant(compareDocumentPosition.call(node, owner) & DOCUMENT_POSITION_CONTAINS, `isNodeOwnedBy() should never be called with a node that is not a child node of ${owner}`);
-  }
-
-  const ownerKey = getNodeNearestOwnerKey(node);
-  return isUndefined(ownerKey) || getNodeKey(owner) === ownerKey;
+    if (true) {
+        assert.invariant(owner instanceof HTMLElement, `isNodeOwnedBy() should be called with an element as the first argument instead of ${owner}`);
+        assert.invariant(node instanceof _Node, `isNodeOwnedBy() should be called with a node as the second argument instead of ${node}`);
+        assert.invariant(compareDocumentPosition.call(node, owner) & DOCUMENT_POSITION_CONTAINS, `isNodeOwnedBy() should never be called with a node that is not a child node of ${owner}`);
+    }
+    const ownerKey = getNodeNearestOwnerKey(node);
+    return isUndefined(ownerKey) || getNodeKey(owner) === ownerKey;
 }
 function shadowRootChildNodes(root) {
-  const elm = getHost(root);
-  return getAllMatches(elm, arrayFromCollection(childNodesGetter.call(elm)));
+    const elm = getHost(root);
+    return getAllMatches(elm, arrayFromCollection(childNodesGetter.call(elm)));
 }
 function getAllSlottedMatches(host, nodeList) {
-  const filteredAndPatched = [];
-
-  for (let i = 0, len = nodeList.length; i < len; i += 1) {
-    const node = nodeList[i];
-
-    if (!isNodeOwnedBy(host, node) && isNodeSlotted(host, node)) {
-      ArrayPush.call(filteredAndPatched, node);
+    const filteredAndPatched = [];
+    for (let i = 0, len = nodeList.length; i < len; i += 1) {
+        const node = nodeList[i];
+        if (!isNodeOwnedBy(host, node) && isNodeSlotted(host, node)) {
+            ArrayPush.call(filteredAndPatched, node);
+        }
     }
-  }
-
-  return filteredAndPatched;
+    return filteredAndPatched;
 }
 function getFirstSlottedMatch(host, nodeList) {
-  for (let i = 0, len = nodeList.length; i < len; i += 1) {
-    const node = nodeList[i];
-
-    if (!isNodeOwnedBy(host, node) && isNodeSlotted(host, node)) {
-      return node;
+    for (let i = 0, len = nodeList.length; i < len; i += 1) {
+        const node = nodeList[i];
+        if (!isNodeOwnedBy(host, node) && isNodeSlotted(host, node)) {
+            return node;
+        }
     }
-  }
-
-  return null;
+    return null;
 }
 function getAllMatches(owner, nodeList) {
-  const filteredAndPatched = [];
-
-  for (let i = 0, len = nodeList.length; i < len; i += 1) {
-    const node = nodeList[i];
-    const isOwned = isNodeOwnedBy(owner, node);
-
-    if (isOwned) {
-      // Patch querySelector, querySelectorAll, etc
-      // if element is owned by VM
-      ArrayPush.call(filteredAndPatched, node);
+    const filteredAndPatched = [];
+    for (let i = 0, len = nodeList.length; i < len; i += 1) {
+        const node = nodeList[i];
+        const isOwned = isNodeOwnedBy(owner, node);
+        if (isOwned) {
+            // Patch querySelector, querySelectorAll, etc
+            // if element is owned by VM
+            ArrayPush.call(filteredAndPatched, node);
+        }
     }
-  }
-
-  return filteredAndPatched;
+    return filteredAndPatched;
 }
 function getFirstMatch(owner, nodeList) {
-  for (let i = 0, len = nodeList.length; i < len; i += 1) {
-    if (isNodeOwnedBy(owner, nodeList[i])) {
-      return nodeList[i];
+    for (let i = 0, len = nodeList.length; i < len; i += 1) {
+        if (isNodeOwnedBy(owner, nodeList[i])) {
+            return nodeList[i];
+        }
     }
-  }
-
-  return null;
+    return null;
 }
 function shadowRootQuerySelector(root, selector) {
-  const elm = getHost(root);
-  const nodeList = arrayFromCollection(querySelectorAll$1.call(elm, selector));
-  return getFirstMatch(elm, nodeList);
+    const elm = getHost(root);
+    const nodeList = arrayFromCollection(querySelectorAll$1.call(elm, selector));
+    return getFirstMatch(elm, nodeList);
 }
 function shadowRootQuerySelectorAll(root, selector) {
-  const elm = getHost(root);
-  const nodeList = querySelectorAll$1.call(elm, selector);
-  return getAllMatches(elm, arrayFromCollection(nodeList));
+    const elm = getHost(root);
+    const nodeList = querySelectorAll$1.call(elm, selector);
+    return getAllMatches(elm, arrayFromCollection(nodeList));
 }
 function getFilteredChildNodes(node) {
-  if (!isSyntheticShadowHost(node) && !isSlotElement(node)) {
-    // regular element - fast path
-    const children = childNodesGetter.call(node);
-    return arrayFromCollection(children);
-  }
-
-  if (isSyntheticShadowHost(node)) {
-    // we need to get only the nodes that were slotted
-    const slots = arrayFromCollection(querySelectorAll$1.call(node, 'slot'));
-    const resolver = getShadowRootResolver(getShadowRoot(node)); // Typescript is inferring the wrong function type for this particular
-    // overloaded method: https://github.com/Microsoft/TypeScript/issues/27972
-    // @ts-ignore type-mismatch
-
-    return ArrayReduce.call(slots, (seed, slot) => {
-      if (resolver === getShadowRootResolver(slot)) {
-        ArrayPush.apply(seed, getFilteredSlotAssignedNodes(slot));
-      }
-
-      return seed;
-    }, []);
-  } else {
-    // slot element
-    const children = arrayFromCollection(childNodesGetter.call(node));
-    const resolver = getShadowRootResolver(node);
-    return ArrayFilter.call(children, child => resolver === getShadowRootResolver(child));
-  }
+    if (!isSyntheticShadowHost(node) && !isSlotElement(node)) {
+        // regular element - fast path
+        const children = childNodesGetter.call(node);
+        return arrayFromCollection(children);
+    }
+    if (isSyntheticShadowHost(node)) {
+        // we need to get only the nodes that were slotted
+        const slots = arrayFromCollection(querySelectorAll$1.call(node, 'slot'));
+        const resolver = getShadowRootResolver(getShadowRoot(node));
+        // Typescript is inferring the wrong function type for this particular
+        // overloaded method: https://github.com/Microsoft/TypeScript/issues/27972
+        // @ts-ignore type-mismatch
+        return ArrayReduce.call(slots, (seed, slot) => {
+            if (resolver === getShadowRootResolver(slot)) {
+                ArrayPush.apply(seed, getFilteredSlotAssignedNodes(slot));
+            }
+            return seed;
+        }, []);
+    }
+    else {
+        // slot element
+        const children = arrayFromCollection(childNodesGetter.call(node));
+        const resolver = getShadowRootResolver(node);
+        return ArrayFilter.call(children, (child) => resolver === getShadowRootResolver(child));
+    }
 }
 function getFilteredSlotAssignedNodes(slot) {
-  const owner = getNodeOwner(slot);
-
-  if (isNull(owner)) {
-    return [];
-  }
-
-  const childNodes = arrayFromCollection(childNodesGetter.call(slot));
-  return ArrayFilter.call(childNodes, child => !isNodeShadowed(child) || !isNodeOwnedBy(owner, child));
-}
-
-/*
- * Copyright (c) 2018, salesforce.com, inc.
- * All rights reserved.
- * SPDX-License-Identifier: MIT
- * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
- */
-function getTextContent(node) {
-  switch (node.nodeType) {
-    case ELEMENT_NODE:
-      {
-        const childNodes = getFilteredChildNodes(node);
-        let content = '';
-
-        for (let i = 0, len = childNodes.length; i < len; i += 1) {
-          const currentNode = childNodes[i];
-
-          if (currentNode.nodeType !== COMMENT_NODE) {
-            content += getTextContent(currentNode);
-          }
-        }
-
-        return content;
-      }
-
-    default:
-      return node.nodeValue;
-  }
-}
-
-/*
- * Copyright (c) 2018, salesforce.com, inc.
- * All rights reserved.
- * SPDX-License-Identifier: MIT
- * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
- */
-const Items$1 = new WeakMap();
-
-function StaticNodeList() {
-  throw new TypeError('Illegal constructor');
-}
-
-StaticNodeList.prototype = create(NodeList.prototype, {
-  constructor: {
-    writable: true,
-    configurable: true,
-    value: StaticNodeList
-  },
-  item: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value(index) {
-      return this[index];
+    const owner = getNodeOwner(slot);
+    if (isNull(owner)) {
+        return [];
     }
-
-  },
-  length: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      return Items$1.get(this).length;
-    }
-
-  },
-  // Iterator protocol
-  forEach: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value(cb, thisArg) {
-      forEach.call(Items$1.get(this), cb, thisArg);
-    }
-
-  },
-  entries: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value() {
-      return ArrayMap.call(Items$1.get(this), (v, i) => [i, v]);
-    }
-
-  },
-  keys: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value() {
-      return ArrayMap.call(Items$1.get(this), (_v, i) => i);
-    }
-
-  },
-  values: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value() {
-      return Items$1.get(this);
-    }
-
-  },
-  [Symbol.iterator]: {
-    writable: true,
-    configurable: true,
-
-    value() {
-      let nextIndex = 0;
-      return {
-        next: () => {
-          const items = Items$1.get(this);
-          return nextIndex < items.length ? {
-            value: items[nextIndex++],
-            done: false
-          } : {
-            done: true
-          };
-        }
-      };
-    }
-
-  },
-  [Symbol.toStringTag]: {
-    configurable: true,
-
-    get() {
-      return 'NodeList';
-    }
-
-  },
-  // IE11 doesn't support Symbol.toStringTag, in which case we
-  // provide the regular toString method.
-  toString: {
-    writable: true,
-    configurable: true,
-
-    value() {
-      return '[object NodeList]';
-    }
-
-  }
-}); // prototype inheritance dance
-
-setPrototypeOf(StaticNodeList, NodeList);
-function createStaticNodeList(items) {
-  const nodeList = create(StaticNodeList.prototype);
-  Items$1.set(nodeList, items); // setting static indexes
-
-  forEach.call(items, (item, index) => {
-    defineProperty(nodeList, index, {
-      value: item,
-      enumerable: true,
-      configurable: true
-    });
-  });
-  return nodeList;
-}
-
-/*
- * Copyright (c) 2018, salesforce.com, inc.
- * All rights reserved.
- * SPDX-License-Identifier: MIT
- * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
- */
-const Items = new WeakMap();
-
-function StaticHTMLCollection() {
-  throw new TypeError('Illegal constructor');
-}
-
-StaticHTMLCollection.prototype = create(HTMLCollection.prototype, {
-  constructor: {
-    writable: true,
-    configurable: true,
-    value: StaticHTMLCollection
-  },
-  item: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value(index) {
-      return this[index];
-    }
-
-  },
-  length: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      return Items.get(this).length;
-    }
-
-  },
-  // https://dom.spec.whatwg.org/#dom-htmlcollection-nameditem-key
-  namedItem: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value(name) {
-      if (name === '') {
-        return null;
-      }
-
-      const items = Items.get(this);
-
-      for (let i = 0, len = items.length; i < len; i++) {
-        const item = items[len];
-
-        if (name === getAttribute.call(item, 'id') || name === getAttribute.call(item, 'name')) {
-          return item;
-        }
-      }
-
-      return null;
-    }
-
-  },
-  [Symbol.toStringTag]: {
-    configurable: true,
-
-    get() {
-      return 'HTMLCollection';
-    }
-
-  },
-  // IE11 doesn't support Symbol.toStringTag, in which case we
-  // provide the regular toString method.
-  toString: {
-    writable: true,
-    configurable: true,
-
-    value() {
-      return '[object HTMLCollection]';
-    }
-
-  }
-}); // prototype inheritance dance
-
-setPrototypeOf(StaticHTMLCollection, HTMLCollection);
-function createStaticHTMLCollection(items) {
-  const collection = create(StaticHTMLCollection.prototype);
-  Items.set(collection, items); // setting static indexes
-
-  forEach.call(items, (item, index) => {
-    defineProperty(collection, index, {
-      value: item,
-      enumerable: true,
-      configurable: true
-    });
-  });
-  return collection;
+    const childNodes = arrayFromCollection(childNodesGetter.call(slot));
+    return ArrayFilter.call(childNodes, (child) => !isNodeShadowed(child) || !isNodeOwnedBy(owner, child));
 }
 
 /*
@@ -1516,14 +724,12 @@ function createStaticHTMLCollection(items) {
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 function getInnerHTML(node) {
-  let s = '';
-  const childNodes = getFilteredChildNodes(node);
-
-  for (let i = 0, len = childNodes.length; i < len; i += 1) {
-    s += getOuterHTML(childNodes[i]);
-  }
-
-  return s;
+    let s = '';
+    const childNodes = getFilteredChildNodes(node);
+    for (let i = 0, len = childNodes.length; i < len; i += 1) {
+        s += getOuterHTML(childNodes[i]);
+    }
+    return s;
 }
 
 /*
@@ -1532,108 +738,398 @@ function getInnerHTML(node) {
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
+// http://www.whatwg.org/specs/web-apps/current-work/multipage/the-end.html#escapingString
 const escapeAttrRegExp = /[&\u00A0"]/g;
 const escapeDataRegExp = /[&\u00A0<>]/g;
-const {
-  replace,
-  toLowerCase
-} = String.prototype;
-
+const { replace, toLowerCase } = String.prototype;
 function escapeReplace(c) {
-  switch (c) {
-    case '&':
-      return '&amp;';
-
-    case '<':
-      return '&lt;';
-
-    case '>':
-      return '&gt;';
-
-    case '"':
-      return '&quot;';
-
-    case '\u00A0':
-      return '&nbsp;';
-
-    default:
-      return '';
-  }
+    switch (c) {
+        case '&':
+            return '&amp;';
+        case '<':
+            return '&lt;';
+        case '>':
+            return '&gt;';
+        case '"':
+            return '&quot;';
+        case '\u00A0':
+            return '&nbsp;';
+        default:
+            return '';
+    }
 }
-
 function escapeAttr(s) {
-  return replace.call(s, escapeAttrRegExp, escapeReplace);
+    return replace.call(s, escapeAttrRegExp, escapeReplace);
 }
-
 function escapeData(s) {
-  return replace.call(s, escapeDataRegExp, escapeReplace);
-} // http://www.whatwg.org/specs/web-apps/current-work/#void-elements
-
-
-const voidElements = new Set(['AREA', 'BASE', 'BR', 'COL', 'COMMAND', 'EMBED', 'HR', 'IMG', 'INPUT', 'KEYGEN', 'LINK', 'META', 'PARAM', 'SOURCE', 'TRACK', 'WBR']);
-const plaintextParents = new Set(['STYLE', 'SCRIPT', 'XMP', 'IFRAME', 'NOEMBED', 'NOFRAMES', 'PLAINTEXT', 'NOSCRIPT']);
-function getOuterHTML(node) {
-  switch (node.nodeType) {
-    case ELEMENT_NODE:
-      {
-        const {
-          attributes: attrs
-        } = node;
-        const tagName = tagNameGetter.call(node);
-        let s = '<' + toLowerCase.call(tagName);
-
-        for (let i = 0, attr; attr = attrs[i]; i++) {
-          s += ' ' + attr.name + '="' + escapeAttr(attr.value) + '"';
-        }
-
-        s += '>';
-
-        if (voidElements.has(tagName)) {
-          return s;
-        }
-
-        return s + getInnerHTML(node) + '</' + toLowerCase.call(tagName) + '>';
-      }
-
-    case TEXT_NODE:
-      {
-        const {
-          data,
-          parentNode
-        } = node;
-
-        if (parentNode instanceof Element && plaintextParents.has(tagNameGetter.call(parentNode))) {
-          return data;
-        }
-
-        return escapeData(data);
-      }
-
-    case CDATA_SECTION_NODE:
-      {
-        return `<!CDATA[[${node.data}]]>`;
-      }
-
-    case PROCESSING_INSTRUCTION_NODE:
-      {
-        return `<?${node.target} ${node.data}?>`;
-      }
-
-    case COMMENT_NODE:
-      {
-        return `<!--${node.data}-->`;
-      }
-
-    default:
-      {
-        // intentionally ignoring unknown node types
-        // Note: since this routine is always invoked for childNodes
-        // we can safety ignore type 9, 10 and 99 (document, fragment and doctype)
-        return '';
-      }
-  }
+    return replace.call(s, escapeDataRegExp, escapeReplace);
 }
+// http://www.whatwg.org/specs/web-apps/current-work/#void-elements
+const voidElements = new Set([
+    'AREA',
+    'BASE',
+    'BR',
+    'COL',
+    'COMMAND',
+    'EMBED',
+    'HR',
+    'IMG',
+    'INPUT',
+    'KEYGEN',
+    'LINK',
+    'META',
+    'PARAM',
+    'SOURCE',
+    'TRACK',
+    'WBR',
+]);
+const plaintextParents = new Set([
+    'STYLE',
+    'SCRIPT',
+    'XMP',
+    'IFRAME',
+    'NOEMBED',
+    'NOFRAMES',
+    'PLAINTEXT',
+    'NOSCRIPT',
+]);
+function getOuterHTML(node) {
+    switch (node.nodeType) {
+        case ELEMENT_NODE: {
+            const { attributes: attrs } = node;
+            const tagName = tagNameGetter.call(node);
+            let s = '<' + toLowerCase.call(tagName);
+            for (let i = 0, attr; (attr = attrs[i]); i++) {
+                s += ' ' + attr.name + '="' + escapeAttr(attr.value) + '"';
+            }
+            s += '>';
+            if (voidElements.has(tagName)) {
+                return s;
+            }
+            return s + getInnerHTML(node) + '</' + toLowerCase.call(tagName) + '>';
+        }
+        case TEXT_NODE: {
+            const { data, parentNode } = node;
+            if (parentNode instanceof Element &&
+                plaintextParents.has(tagNameGetter.call(parentNode))) {
+                return data;
+            }
+            return escapeData(data);
+        }
+        case CDATA_SECTION_NODE: {
+            return `<!CDATA[[${node.data}]]>`;
+        }
+        case PROCESSING_INSTRUCTION_NODE: {
+            return `<?${node.target} ${node.data}?>`;
+        }
+        case COMMENT_NODE: {
+            return `<!--${node.data}-->`;
+        }
+        default: {
+            // intentionally ignoring unknown node types
+            // Note: since this routine is always invoked for childNodes
+            // we can safety ignore type 9, 10 and 99 (document, fragment and doctype)
+            return '';
+        }
+    }
+}
+
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+function getTextContent(node) {
+    switch (node.nodeType) {
+        case ELEMENT_NODE: {
+            const childNodes = getFilteredChildNodes(node);
+            let content = '';
+            for (let i = 0, len = childNodes.length; i < len; i += 1) {
+                const currentNode = childNodes[i];
+                if (currentNode.nodeType !== COMMENT_NODE) {
+                    content += getTextContent(currentNode);
+                }
+            }
+            return content;
+        }
+        default:
+            return node.nodeValue;
+    }
+}
+
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const Items$1 = new WeakMap();
+function StaticNodeList() {
+    throw new TypeError('Illegal constructor');
+}
+StaticNodeList.prototype = create(NodeList.prototype, {
+    constructor: {
+        writable: true,
+        configurable: true,
+        value: StaticNodeList,
+    },
+    item: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(index) {
+            return this[index];
+        },
+    },
+    length: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            return Items$1.get(this).length;
+        },
+    },
+    // Iterator protocol
+    forEach: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(cb, thisArg) {
+            forEach.call(Items$1.get(this), cb, thisArg);
+        },
+    },
+    entries: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value() {
+            return ArrayMap.call(Items$1.get(this), (v, i) => [i, v]);
+        },
+    },
+    keys: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value() {
+            return ArrayMap.call(Items$1.get(this), (_v, i) => i);
+        },
+    },
+    values: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value() {
+            return Items$1.get(this);
+        },
+    },
+    [Symbol.iterator]: {
+        writable: true,
+        configurable: true,
+        value() {
+            let nextIndex = 0;
+            return {
+                next: () => {
+                    const items = Items$1.get(this);
+                    return nextIndex < items.length
+                        ? {
+                            value: items[nextIndex++],
+                            done: false,
+                        }
+                        : {
+                            done: true,
+                        };
+                },
+            };
+        },
+    },
+    [Symbol.toStringTag]: {
+        configurable: true,
+        get() {
+            return 'NodeList';
+        },
+    },
+    // IE11 doesn't support Symbol.toStringTag, in which case we
+    // provide the regular toString method.
+    toString: {
+        writable: true,
+        configurable: true,
+        value() {
+            return '[object NodeList]';
+        },
+    },
+});
+// prototype inheritance dance
+setPrototypeOf(StaticNodeList, NodeList);
+function createStaticNodeList(items) {
+    const nodeList = create(StaticNodeList.prototype);
+    Items$1.set(nodeList, items);
+    // setting static indexes
+    forEach.call(items, (item, index) => {
+        defineProperty(nodeList, index, {
+            value: item,
+            enumerable: true,
+            configurable: true,
+        });
+    });
+    return nodeList;
+}
+
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+// Walk up the DOM tree, collecting all shadow roots plus the document root
+function getAllRootNodes(node) {
+    var _a;
+    const rootNodes = [];
+    let currentRootNode = node.getRootNode();
+    while (!isUndefined(currentRootNode)) {
+        rootNodes.push(currentRootNode);
+        currentRootNode = (_a = currentRootNode.host) === null || _a === void 0 ? void 0 : _a.getRootNode();
+    }
+    return rootNodes;
+}
+// Keep searching up the host tree until we find an element that is within the immediate shadow root
+const findAncestorHostInImmediateShadowRoot = (rootNode, targetRootNode) => {
+    let host;
+    while (!isUndefined((host = rootNode.host))) {
+        const thisRootNode = host.getRootNode();
+        if (thisRootNode === targetRootNode) {
+            return host;
+        }
+        rootNode = thisRootNode;
+    }
+};
+function fauxElementsFromPoint(context, doc, left, top) {
+    const elements = elementsFromPoint.call(doc, left, top);
+    const result = [];
+    const rootNodes = getAllRootNodes(context);
+    // Filter the elements array to only include those elements that are in this shadow root or in one of its
+    // ancestor roots. This matches Chrome and Safari's implementation (but not Firefox's, which only includes
+    // elements in the immediate shadow root: https://crbug.com/1207863#c4).
+    if (!isNull(elements)) {
+        // can be null in IE https://developer.mozilla.org/en-US/docs/Web/API/Document/elementsFromPoint#browser_compatibility
+        for (let i = 0; i < elements.length; i++) {
+            const element = elements[i];
+            if (isSyntheticSlotElement(element)) {
+                continue;
+            }
+            const elementRootNode = element.getRootNode();
+            if (ArrayIndexOf.call(rootNodes, elementRootNode) !== -1) {
+                ArrayPush.call(result, element);
+                continue;
+            }
+            // In cases where the host element is not visible but its shadow descendants are, then
+            // we may get the shadow descendant instead of the host element here. (The
+            // browser doesn't know the difference in synthetic shadow DOM.)
+            // In native shadow DOM, however, elementsFromPoint would return the host but not
+            // the child. So we need to detect if this shadow element's host is accessible from
+            // the context's shadow root. Note we also need to be careful not to add the host
+            // multiple times.
+            const ancestorHost = findAncestorHostInImmediateShadowRoot(elementRootNode, rootNodes[0]);
+            if (!isUndefined(ancestorHost) &&
+                ArrayIndexOf.call(elements, ancestorHost) === -1 &&
+                ArrayIndexOf.call(result, ancestorHost) === -1) {
+                ArrayPush.call(result, ancestorHost);
+            }
+        }
+    }
+    return result;
+}
+
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const Items = new WeakMap();
+function StaticHTMLCollection() {
+    throw new TypeError('Illegal constructor');
+}
+StaticHTMLCollection.prototype = create(HTMLCollection.prototype, {
+    constructor: {
+        writable: true,
+        configurable: true,
+        value: StaticHTMLCollection,
+    },
+    item: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(index) {
+            return this[index];
+        },
+    },
+    length: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            return Items.get(this).length;
+        },
+    },
+    // https://dom.spec.whatwg.org/#dom-htmlcollection-nameditem-key
+    namedItem: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(name) {
+            if (name === '') {
+                return null;
+            }
+            const items = Items.get(this);
+            for (let i = 0, len = items.length; i < len; i++) {
+                const item = items[len];
+                if (name === getAttribute.call(item, 'id') ||
+                    name === getAttribute.call(item, 'name')) {
+                    return item;
+                }
+            }
+            return null;
+        },
+    },
+    [Symbol.toStringTag]: {
+        configurable: true,
+        get() {
+            return 'HTMLCollection';
+        },
+    },
+    // IE11 doesn't support Symbol.toStringTag, in which case we
+    // provide the regular toString method.
+    toString: {
+        writable: true,
+        configurable: true,
+        value() {
+            return '[object HTMLCollection]';
+        },
+    },
+});
+// prototype inheritance dance
+setPrototypeOf(StaticHTMLCollection, HTMLCollection);
+function createStaticHTMLCollection(items) {
+    const collection = create(StaticHTMLCollection.prototype);
+    Items.set(collection, items);
+    // setting static indexes
+    forEach.call(items, (item, index) => {
+        defineProperty(collection, index, {
+            value: item,
+            enumerable: true,
+            configurable: true,
+        });
+    });
+    return collection;
+}
+
+/**
+ * Copyright (C) 2018 salesforce.com, inc.
+ */
+if (!_globalThis.lwcRuntimeFlags) {
+    Object.defineProperty(_globalThis, 'lwcRuntimeFlags', { value: create(null) });
+}
+const lwcRuntimeFlags = _globalThis.lwcRuntimeFlags;
+/** version: 2.23.2 */
 
 /*
  * Copyright (c) 2018, salesforce.com, inc.
@@ -1726,7 +1222,9 @@ function parentElementGetterPatched() {
 }
 
 function compareDocumentPositionPatched(otherNode) {
-  if (this.getRootNode() === otherNode) {
+  if (this === otherNode) {
+    return 0;
+  } else if (this.getRootNode() === otherNode) {
     // "this" is in a shadow tree where the shadow root is the "otherNode".
     return 10; // Node.DOCUMENT_POSITION_CONTAINS | Node.DOCUMENT_POSITION_PRECEDING
   } else if (getNodeOwnerKey(this) !== getNodeOwnerKey(otherNode)) {
@@ -1882,7 +1380,7 @@ defineProperties(_Node.prototype, {
   },
   textContent: {
     get() {
-      if (!runtimeFlags.ENABLE_NODE_PATCH) {
+      if (!lwcRuntimeFlags.ENABLE_NODE_PATCH) {
         if (isNodeShadowed(this) || isSyntheticShadowHost(this)) {
           return textContentGetterPatched.call(this);
         }
@@ -1989,7 +1487,7 @@ defineProperties(_Node.prototype, {
         return true;
       }
 
-      if (!runtimeFlags.ENABLE_NODE_PATCH) {
+      if (!lwcRuntimeFlags.ENABLE_NODE_PATCH) {
         if (otherNode == null) {
           return false;
         }
@@ -2015,7 +1513,7 @@ defineProperties(_Node.prototype, {
   },
   cloneNode: {
     value(deep) {
-      if (!runtimeFlags.ENABLE_NODE_PATCH) {
+      if (!lwcRuntimeFlags.ENABLE_NODE_PATCH) {
         if (isNodeShadowed(this) || isSyntheticShadowHost(this)) {
           return cloneNodePatched.call(this, deep);
         }
@@ -2104,40 +1602,241 @@ if (hasOwnProperty.call(HTMLElement.prototype, 'parentElement')) {
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
-function getAllRootNodes(node) {
-  var _a;
-
-  const rootNodes = [];
-  let currentRootNode = node.getRootNode();
-
-  while (!isUndefined(currentRootNode)) {
-    rootNodes.push(currentRootNode);
-    currentRootNode = (_a = currentRootNode.host) === null || _a === void 0 ? void 0 : _a.getRootNode();
-  }
-
-  return rootNodes;
+const EventListenerMap = new WeakMap();
+const ComposedPathMap = new WeakMap();
+function isEventListenerOrEventListenerObject(fnOrObj) {
+    return (isFunction(fnOrObj) ||
+        (isObject(fnOrObj) &&
+            !isNull(fnOrObj) &&
+            isFunction(fnOrObj.handleEvent)));
+}
+function shouldInvokeListener(event, target, currentTarget) {
+    // Subsequent logic assumes that `currentTarget` must be contained in the composed path for the listener to be
+    // invoked, but this is not always the case. `composedPath()` will sometimes return an empty array, even when the
+    // listener should be invoked (e.g., a disconnected instance of EventTarget, an instance of XMLHttpRequest, etc).
+    if (target === currentTarget) {
+        return true;
+    }
+    let composedPath = ComposedPathMap.get(event);
+    if (isUndefined(composedPath)) {
+        composedPath = event.composedPath();
+        ComposedPathMap.set(event, composedPath);
+    }
+    return composedPath.includes(currentTarget);
+}
+function getEventListenerWrapper(fnOrObj) {
+    if (!isEventListenerOrEventListenerObject(fnOrObj)) {
+        return fnOrObj;
+    }
+    let wrapperFn = EventListenerMap.get(fnOrObj);
+    if (isUndefined(wrapperFn)) {
+        wrapperFn = function (event) {
+            // This function is invoked from an event listener and currentTarget is always defined.
+            const currentTarget = eventCurrentTargetGetter.call(event);
+            if (true) {
+                assert.invariant(isFalse(isSyntheticShadowHost(currentTarget)), 'This routine should not be used to wrap event listeners for host elements and shadow roots.');
+            }
+            const actualTarget = getActualTarget(event);
+            if (!shouldInvokeListener(event, actualTarget, currentTarget)) {
+                return;
+            }
+            return isFunction(fnOrObj)
+                ? fnOrObj.call(this, event)
+                : fnOrObj.handleEvent && fnOrObj.handleEvent(event);
+        };
+        EventListenerMap.set(fnOrObj, wrapperFn);
+    }
+    return wrapperFn;
 }
 
-function fauxElementsFromPoint(context, doc, left, top) {
-  const elements = elementsFromPoint.call(doc, left, top);
-  const result = [];
-  const rootNodes = getAllRootNodes(context); // Filter the elements array to only include those elements that are in this shadow root or in one of its
-  // ancestor roots. This matches Chrome and Safari's implementation (but not Firefox's, which only includes
-  // elements in the immediate shadow root: https://crbug.com/1207863#c4).
-
-  if (!isNull(elements)) {
-    // can be null in IE https://developer.mozilla.org/en-US/docs/Web/API/Document/elementsFromPoint#browser_compatibility
-    for (let i = 0; i < elements.length; i++) {
-      const element = elements[i];
-
-      if (rootNodes.indexOf(element.getRootNode()) !== -1 && !isSyntheticSlotElement(element)) {
-        result.push(element);
-      }
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const eventToContextMap = new WeakMap();
+const customElementToWrappedListeners = new WeakMap();
+function getEventMap(elm) {
+    let listenerInfo = customElementToWrappedListeners.get(elm);
+    if (isUndefined(listenerInfo)) {
+        listenerInfo = create(null);
+        customElementToWrappedListeners.set(elm, listenerInfo);
     }
-  }
-
-  return result;
+    return listenerInfo;
+}
+/**
+ * Events dispatched on shadow roots actually end up being dispatched on their hosts. This means that the event.target
+ * property of events dispatched on shadow roots always resolve to their host. This function understands this
+ * abstraction and properly returns a reference to the shadow root when appropriate.
+ */
+function getActualTarget(event) {
+    var _a;
+    return (_a = eventToShadowRootMap.get(event)) !== null && _a !== void 0 ? _a : eventTargetGetter.call(event);
+}
+const shadowRootEventListenerMap = new WeakMap();
+function getWrappedShadowRootListener(listener) {
+    if (!isFunction(listener)) {
+        throw new TypeError(); // avoiding problems with non-valid listeners
+    }
+    let shadowRootWrappedListener = shadowRootEventListenerMap.get(listener);
+    if (isUndefined(shadowRootWrappedListener)) {
+        shadowRootWrappedListener = function (event) {
+            // currentTarget is always defined inside an event listener
+            let currentTarget = eventCurrentTargetGetter.call(event);
+            // If currentTarget is not an instance of a native shadow root then we're dealing with a
+            // host element whose synthetic shadow root must be accessed via getShadowRoot().
+            if (!isInstanceOfNativeShadowRoot(currentTarget)) {
+                currentTarget = getShadowRoot(currentTarget);
+            }
+            const actualTarget = getActualTarget(event);
+            if (shouldInvokeListener(event, actualTarget, currentTarget)) {
+                listener.call(currentTarget, event);
+            }
+        };
+        shadowRootWrappedListener.placement = 1 /* EventListenerContext.SHADOW_ROOT_LISTENER */;
+        shadowRootEventListenerMap.set(listener, shadowRootWrappedListener);
+    }
+    return shadowRootWrappedListener;
+}
+const customElementEventListenerMap = new WeakMap();
+function getWrappedCustomElementListener(listener) {
+    if (!isFunction(listener)) {
+        throw new TypeError(); // avoiding problems with non-valid listeners
+    }
+    let customElementWrappedListener = customElementEventListenerMap.get(listener);
+    if (isUndefined(customElementWrappedListener)) {
+        customElementWrappedListener = function (event) {
+            // currentTarget is always defined inside an event listener
+            const currentTarget = eventCurrentTargetGetter.call(event);
+            const actualTarget = getActualTarget(event);
+            if (shouldInvokeListener(event, actualTarget, currentTarget)) {
+                listener.call(currentTarget, event);
+            }
+        };
+        customElementWrappedListener.placement = 0 /* EventListenerContext.CUSTOM_ELEMENT_LISTENER */;
+        customElementEventListenerMap.set(listener, customElementWrappedListener);
+    }
+    return customElementWrappedListener;
+}
+function domListener(evt) {
+    let immediatePropagationStopped = false;
+    let propagationStopped = false;
+    const { type, stopImmediatePropagation, stopPropagation } = evt;
+    // currentTarget is always defined
+    const currentTarget = eventCurrentTargetGetter.call(evt);
+    const listenerMap = getEventMap(currentTarget);
+    const listeners = listenerMap[type]; // it must have listeners at this point
+    defineProperty(evt, 'stopImmediatePropagation', {
+        value() {
+            immediatePropagationStopped = true;
+            stopImmediatePropagation.call(evt);
+        },
+        writable: true,
+        enumerable: true,
+        configurable: true,
+    });
+    defineProperty(evt, 'stopPropagation', {
+        value() {
+            propagationStopped = true;
+            stopPropagation.call(evt);
+        },
+        writable: true,
+        enumerable: true,
+        configurable: true,
+    });
+    // in case a listener adds or removes other listeners during invocation
+    const bookkeeping = ArraySlice.call(listeners);
+    function invokeListenersByPlacement(placement) {
+        forEach.call(bookkeeping, (listener) => {
+            if (isFalse(immediatePropagationStopped) && listener.placement === placement) {
+                // making sure that the listener was not removed from the original listener queue
+                if (ArrayIndexOf.call(listeners, listener) !== -1) {
+                    // all handlers on the custom element should be called with undefined 'this'
+                    listener.call(undefined, evt);
+                }
+            }
+        });
+    }
+    eventToContextMap.set(evt, 1 /* EventListenerContext.SHADOW_ROOT_LISTENER */);
+    invokeListenersByPlacement(1 /* EventListenerContext.SHADOW_ROOT_LISTENER */);
+    if (isFalse(immediatePropagationStopped) && isFalse(propagationStopped)) {
+        // doing the second iteration only if the first one didn't interrupt the event propagation
+        eventToContextMap.set(evt, 0 /* EventListenerContext.CUSTOM_ELEMENT_LISTENER */);
+        invokeListenersByPlacement(0 /* EventListenerContext.CUSTOM_ELEMENT_LISTENER */);
+    }
+    eventToContextMap.set(evt, 2 /* EventListenerContext.UNKNOWN_LISTENER */);
+}
+function attachDOMListener(elm, type, wrappedListener) {
+    const listenerMap = getEventMap(elm);
+    let cmpEventHandlers = listenerMap[type];
+    if (isUndefined(cmpEventHandlers)) {
+        cmpEventHandlers = listenerMap[type] = [];
+    }
+    // Prevent identical listeners from subscribing to the same event type.
+    // TODO [#1824]: Options will also play a factor when we introduce support for them (#1824).
+    if (ArrayIndexOf.call(cmpEventHandlers, wrappedListener) !== -1) {
+        return;
+    }
+    // only add to DOM if there is no other listener on the same placement yet
+    if (cmpEventHandlers.length === 0) {
+        // super.addEventListener() - this will not work on
+        addEventListener.call(elm, type, domListener);
+    }
+    ArrayPush.call(cmpEventHandlers, wrappedListener);
+}
+function detachDOMListener(elm, type, wrappedListener) {
+    const listenerMap = getEventMap(elm);
+    let p;
+    let listeners;
+    if (!isUndefined((listeners = listenerMap[type])) &&
+        (p = ArrayIndexOf.call(listeners, wrappedListener)) !== -1) {
+        ArraySplice.call(listeners, p, 1);
+        // only remove from DOM if there is no other listener on the same placement
+        if (listeners.length === 0) {
+            removeEventListener.call(elm, type, domListener);
+        }
+    }
+}
+function addCustomElementEventListener(type, listener, _options) {
+    if (true) {
+        if (!isFunction(listener)) {
+            throw new TypeError(`Invalid second argument for Element.addEventListener() in ${toString(this)} for event "${type}". Expected an EventListener but received ${listener}.`);
+        }
+    }
+    // TODO [#1824]: Lift this restriction on the option parameter
+    if (isFunction(listener)) {
+        const wrappedListener = getWrappedCustomElementListener(listener);
+        attachDOMListener(this, type, wrappedListener);
+    }
+}
+function removeCustomElementEventListener(type, listener, _options) {
+    // TODO [#1824]: Lift this restriction on the option parameter
+    if (isFunction(listener)) {
+        const wrappedListener = getWrappedCustomElementListener(listener);
+        detachDOMListener(this, type, wrappedListener);
+    }
+}
+function addShadowRootEventListener(sr, type, listener, _options) {
+    if (true) {
+        if (!isFunction(listener)) {
+            throw new TypeError(`Invalid second argument for ShadowRoot.addEventListener() in ${toString(sr)} for event "${type}". Expected an EventListener but received ${listener}.`);
+        }
+    }
+    // TODO [#1824]: Lift this restriction on the option parameter
+    if (isFunction(listener)) {
+        const elm = getHost(sr);
+        const wrappedListener = getWrappedShadowRootListener(listener);
+        attachDOMListener(elm, type, wrappedListener);
+    }
+}
+function removeShadowRootEventListener(sr, type, listener, _options) {
+    // TODO [#1824]: Lift this restriction on the option parameter
+    if (isFunction(listener)) {
+        const elm = getHost(sr);
+        const wrappedListener = getWrappedShadowRootListener(listener);
+        detachDOMListener(elm, type, wrappedListener);
+    }
 }
 
 /*
@@ -2147,623 +1846,524 @@ function fauxElementsFromPoint(context, doc, left, top) {
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const InternalSlot = new WeakMap();
-const {
-  createDocumentFragment
-} = document;
+const { createDocumentFragment } = document;
 function hasInternalSlot(root) {
-  return InternalSlot.has(root);
+    return InternalSlot.has(root);
 }
-
 function getInternalSlot(root) {
-  const record = InternalSlot.get(root);
-
-  if (isUndefined(record)) {
-    throw new TypeError();
-  }
-
-  return record;
+    const record = InternalSlot.get(root);
+    if (isUndefined(record)) {
+        throw new TypeError();
+    }
+    return record;
 }
-
 defineProperty(_Node.prototype, KEY__SHADOW_RESOLVER, {
-  set(fn) {
-    if (isUndefined(fn)) return;
-    this[KEY__SHADOW_RESOLVER_PRIVATE] = fn; // TODO [#1164]: temporary propagation of the key
-
-    setNodeOwnerKey(this, fn.nodeKey);
-  },
-
-  get() {
-    return this[KEY__SHADOW_RESOLVER_PRIVATE];
-  },
-
-  configurable: true,
-  enumerable: true
+    set(fn) {
+        if (isUndefined(fn))
+            return;
+        this[KEY__SHADOW_RESOLVER_PRIVATE] = fn;
+        // TODO [#1164]: temporary propagation of the key
+        setNodeOwnerKey(this, fn.nodeKey);
+    },
+    get() {
+        return this[KEY__SHADOW_RESOLVER_PRIVATE];
+    },
+    configurable: true,
+    enumerable: true,
 });
 defineProperty(_globalThis, KEY__IS_NATIVE_SHADOW_ROOT_DEFINED, {
-  value: isNativeShadowRootDefined
+    value: isNativeShadowRootDefined,
 });
 function getShadowRootResolver(node) {
-  return node[KEY__SHADOW_RESOLVER];
+    return node[KEY__SHADOW_RESOLVER];
 }
 function setShadowRootResolver(node, fn) {
-  node[KEY__SHADOW_RESOLVER] = fn;
+    node[KEY__SHADOW_RESOLVER] = fn;
 }
 function isDelegatingFocus(host) {
-  return getInternalSlot(host).delegatesFocus;
+    return getInternalSlot(host).delegatesFocus;
 }
 function getHost(root) {
-  return getInternalSlot(root).host;
+    return getInternalSlot(root).host;
 }
 function getShadowRoot(elm) {
-  return getInternalSlot(elm).shadowRoot;
-} // Intentionally adding `Node` here in addition to `Element` since this check is harmless for nodes
+    return getInternalSlot(elm).shadowRoot;
+}
+// Intentionally adding `Node` here in addition to `Element` since this check is harmless for nodes
 // and we can avoid having to cast the type before calling this method in a few places.
-
 function isSyntheticShadowHost(node) {
-  const shadowRootRecord = InternalSlot.get(node);
-  return !isUndefined(shadowRootRecord) && node === shadowRootRecord.host;
+    const shadowRootRecord = InternalSlot.get(node);
+    return !isUndefined(shadowRootRecord) && node === shadowRootRecord.host;
 }
 function isSyntheticShadowRoot(node) {
-  const shadowRootRecord = InternalSlot.get(node);
-  return !isUndefined(shadowRootRecord) && node === shadowRootRecord.shadowRoot;
+    const shadowRootRecord = InternalSlot.get(node);
+    return !isUndefined(shadowRootRecord) && node === shadowRootRecord.shadowRoot;
 }
 let uid = 0;
 function attachShadow(elm, options) {
-  if (InternalSlot.has(elm)) {
-    throw new Error(`Failed to execute 'attachShadow' on 'Element': Shadow root cannot be created on a host which already hosts a shadow tree.`);
-  }
-
-  const {
-    mode,
-    delegatesFocus
-  } = options; // creating a real fragment for shadowRoot instance
-
-  const doc = getOwnerDocument(elm);
-  const sr = createDocumentFragment.call(doc); // creating shadow internal record
-
-  const record = {
-    mode,
-    delegatesFocus: !!delegatesFocus,
-    host: elm,
-    shadowRoot: sr
-  };
-  InternalSlot.set(sr, record);
-  InternalSlot.set(elm, record);
-
-  const shadowResolver = () => sr;
-
-  const x = shadowResolver.nodeKey = uid++;
-  setNodeKey(elm, x);
-  setShadowRootResolver(sr, shadowResolver); // correcting the proto chain
-
-  setPrototypeOf(sr, SyntheticShadowRoot.prototype);
-  return sr;
+    if (InternalSlot.has(elm)) {
+        throw new Error(`Failed to execute 'attachShadow' on 'Element': Shadow root cannot be created on a host which already hosts a shadow tree.`);
+    }
+    const { mode, delegatesFocus } = options;
+    // creating a real fragment for shadowRoot instance
+    const doc = getOwnerDocument(elm);
+    const sr = createDocumentFragment.call(doc);
+    // creating shadow internal record
+    const record = {
+        mode,
+        delegatesFocus: !!delegatesFocus,
+        host: elm,
+        shadowRoot: sr,
+    };
+    InternalSlot.set(sr, record);
+    InternalSlot.set(elm, record);
+    const shadowResolver = () => sr;
+    const x = (shadowResolver.nodeKey = uid++);
+    setNodeKey(elm, x);
+    setShadowRootResolver(sr, shadowResolver);
+    // correcting the proto chain
+    setPrototypeOf(sr, SyntheticShadowRoot.prototype);
+    return sr;
 }
 const SyntheticShadowRootDescriptors = {
-  constructor: {
-    writable: true,
-    configurable: true,
-    value: SyntheticShadowRoot
-  },
-  toString: {
-    writable: true,
-    configurable: true,
-
-    value() {
-      return `[object ShadowRoot]`;
-    }
-
-  }
+    constructor: {
+        writable: true,
+        configurable: true,
+        value: SyntheticShadowRoot,
+    },
+    toString: {
+        writable: true,
+        configurable: true,
+        value() {
+            return `[object ShadowRoot]`;
+        },
+    },
+    synthetic: {
+        writable: false,
+        enumerable: false,
+        configurable: false,
+        value: true,
+    },
 };
 const ShadowRootDescriptors = {
-  activeElement: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      const host = getHost(this);
-      const doc = getOwnerDocument(host);
-      const activeElement = DocumentPrototypeActiveElement.call(doc);
-
-      if (isNull(activeElement)) {
-        return activeElement;
-      }
-
-      if ((compareDocumentPosition.call(host, activeElement) & DOCUMENT_POSITION_CONTAINED_BY) === 0) {
-        return null;
-      } // activeElement must be child of the host and owned by it
-
-
-      let node = activeElement;
-
-      while (!isNodeOwnedBy(host, node)) {
-        // parentElement is always an element because we are talking up the tree knowing
-        // that it is a child of the host.
-        node = parentElementGetter.call(node);
-      } // If we have a slot element here that means that we were dealing
-      // with an element that was passed to one of our slots. In this
-      // case, activeElement returns null.
-
-
-      if (isSlotElement(node)) {
-        return null;
-      }
-
-      return node;
-    }
-
-  },
-  delegatesFocus: {
-    configurable: true,
-
-    get() {
-      return getInternalSlot(this).delegatesFocus;
-    }
-
-  },
-  elementFromPoint: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value(left, top) {
-      const host = getHost(this);
-      const doc = getOwnerDocument(host);
-      return fauxElementFromPoint(this, doc, left, top);
-    }
-
-  },
-  elementsFromPoint: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value(left, top) {
-      const host = getHost(this);
-      const doc = getOwnerDocument(host);
-      return fauxElementsFromPoint(this, doc, left, top);
-    }
-
-  },
-  getSelection: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value() {
-      throw new Error('Disallowed method "getSelection" on ShadowRoot.');
-    }
-
-  },
-  host: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      return getHost(this);
-    }
-
-  },
-  mode: {
-    configurable: true,
-
-    get() {
-      return getInternalSlot(this).mode;
-    }
-
-  },
-  styleSheets: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      throw new Error();
-    }
-
-  }
+    activeElement: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            const host = getHost(this);
+            const doc = getOwnerDocument(host);
+            const activeElement = DocumentPrototypeActiveElement.call(doc);
+            if (isNull(activeElement)) {
+                return activeElement;
+            }
+            if ((compareDocumentPosition.call(host, activeElement) &
+                DOCUMENT_POSITION_CONTAINED_BY) ===
+                0) {
+                return null;
+            }
+            // activeElement must be child of the host and owned by it
+            let node = activeElement;
+            while (!isNodeOwnedBy(host, node)) {
+                // parentElement is always an element because we are talking up the tree knowing
+                // that it is a child of the host.
+                node = parentElementGetter.call(node);
+            }
+            // If we have a slot element here that means that we were dealing
+            // with an element that was passed to one of our slots. In this
+            // case, activeElement returns null.
+            if (isSlotElement(node)) {
+                return null;
+            }
+            return node;
+        },
+    },
+    delegatesFocus: {
+        configurable: true,
+        get() {
+            return getInternalSlot(this).delegatesFocus;
+        },
+    },
+    elementFromPoint: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(left, top) {
+            const host = getHost(this);
+            const doc = getOwnerDocument(host);
+            return fauxElementFromPoint(this, doc, left, top);
+        },
+    },
+    elementsFromPoint: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(left, top) {
+            const host = getHost(this);
+            const doc = getOwnerDocument(host);
+            return fauxElementsFromPoint(this, doc, left, top);
+        },
+    },
+    getSelection: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value() {
+            throw new Error('Disallowed method "getSelection" on ShadowRoot.');
+        },
+    },
+    host: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            return getHost(this);
+        },
+    },
+    mode: {
+        configurable: true,
+        get() {
+            return getInternalSlot(this).mode;
+        },
+    },
+    styleSheets: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            throw new Error();
+        },
+    },
 };
 const eventToShadowRootMap = new WeakMap();
 const NodePatchDescriptors = {
-  insertBefore: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value(newChild, refChild) {
-      insertBefore.call(getHost(this), newChild, refChild);
-      return newChild;
-    }
-
-  },
-  removeChild: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value(oldChild) {
-      removeChild.call(getHost(this), oldChild);
-      return oldChild;
-    }
-
-  },
-  appendChild: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value(newChild) {
-      appendChild.call(getHost(this), newChild);
-      return newChild;
-    }
-
-  },
-  replaceChild: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value(newChild, oldChild) {
-      replaceChild.call(getHost(this), newChild, oldChild);
-      return oldChild;
-    }
-
-  },
-  addEventListener: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value(type, listener, options) {
-      addShadowRootEventListener(this, type, listener);
-    }
-
-  },
-  dispatchEvent: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value(evt) {
-      eventToShadowRootMap.set(evt, this); // Typescript does not like it when you treat the `arguments` object as an array
-      // @ts-ignore type-mismatch
-
-      return dispatchEvent.apply(getHost(this), arguments);
-    }
-
-  },
-  removeEventListener: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value(type, listener, options) {
-      removeShadowRootEventListener(this, type, listener);
-    }
-
-  },
-  baseURI: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      return getHost(this).baseURI;
-    }
-
-  },
-  childNodes: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      return createStaticNodeList(shadowRootChildNodes(this));
-    }
-
-  },
-  cloneNode: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value() {
-      throw new Error('Disallowed method "cloneNode" on ShadowRoot.');
-    }
-
-  },
-  compareDocumentPosition: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value(otherNode) {
-      const host = getHost(this);
-
-      if (this === otherNode) {
-        // "this" and "otherNode" are the same shadow root.
-        return 0;
-      } else if (this.contains(otherNode)) {
-        // "otherNode" belongs to the shadow tree where "this" is the shadow root.
-        return 20; // Node.DOCUMENT_POSITION_CONTAINED_BY | Node.DOCUMENT_POSITION_FOLLOWING
-      } else if (compareDocumentPosition.call(host, otherNode) & DOCUMENT_POSITION_CONTAINED_BY) {
-        // "otherNode" is in a different shadow tree contained by the shadow tree where "this" is the shadow root.
-        return 37; // Node.DOCUMENT_POSITION_DISCONNECTED | Node.DOCUMENT_POSITION_FOLLOWING | Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC
-      } else {
-        // "otherNode" is in a different shadow tree that is not contained by the shadow tree where "this" is the shadow root.
-        return 35; // Node.DOCUMENT_POSITION_DISCONNECTED | Node.DOCUMENT_POSITION_PRECEDING | Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC
-      }
-    }
-
-  },
-  contains: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value(otherNode) {
-      if (this === otherNode) {
-        return true;
-      }
-
-      const host = getHost(this); // must be child of the host and owned by it.
-
-      return (compareDocumentPosition.call(host, otherNode) & DOCUMENT_POSITION_CONTAINED_BY) !== 0 && isNodeOwnedBy(host, otherNode);
-    }
-
-  },
-  firstChild: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      const childNodes = getInternalChildNodes(this);
-      return childNodes[0] || null;
-    }
-
-  },
-  lastChild: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      const childNodes = getInternalChildNodes(this);
-      return childNodes[childNodes.length - 1] || null;
-    }
-
-  },
-  hasChildNodes: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value() {
-      const childNodes = getInternalChildNodes(this);
-      return childNodes.length > 0;
-    }
-
-  },
-  isConnected: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      return isConnected.call(getHost(this));
-    }
-
-  },
-  nextSibling: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      return null;
-    }
-
-  },
-  previousSibling: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      return null;
-    }
-
-  },
-  nodeName: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      return '#document-fragment';
-    }
-
-  },
-  nodeType: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      return 11; // Node.DOCUMENT_FRAGMENT_NODE
-    }
-
-  },
-  nodeValue: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      return null;
-    }
-
-  },
-  ownerDocument: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      return getHost(this).ownerDocument;
-    }
-
-  },
-  parentElement: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      return null;
-    }
-
-  },
-  parentNode: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      return null;
-    }
-
-  },
-  textContent: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      const childNodes = getInternalChildNodes(this);
-      let textContent = '';
-
-      for (let i = 0, len = childNodes.length; i < len; i += 1) {
-        const currentNode = childNodes[i];
-
-        if (currentNode.nodeType !== COMMENT_NODE) {
-          textContent += getTextContent(currentNode);
-        }
-      }
-
-      return textContent;
+    insertBefore: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(newChild, refChild) {
+            insertBefore.call(getHost(this), newChild, refChild);
+            return newChild;
+        },
     },
-
-    set(v) {
-      const host = getHost(this);
-      textContextSetter.call(host, v);
-    }
-
-  },
-  // Since the synthetic shadow root is a detached DocumentFragment, short-circuit the getRootNode behavior
-  getRootNode: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value(options) {
-      return !isUndefined(options) && isTrue(options.composed) ? getHost(this).getRootNode(options) : this;
-    }
-
-  }
+    removeChild: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(oldChild) {
+            removeChild.call(getHost(this), oldChild);
+            return oldChild;
+        },
+    },
+    appendChild: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(newChild) {
+            appendChild.call(getHost(this), newChild);
+            return newChild;
+        },
+    },
+    replaceChild: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(newChild, oldChild) {
+            replaceChild.call(getHost(this), newChild, oldChild);
+            return oldChild;
+        },
+    },
+    addEventListener: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(type, listener, options) {
+            addShadowRootEventListener(this, type, listener);
+        },
+    },
+    dispatchEvent: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(evt) {
+            eventToShadowRootMap.set(evt, this);
+            // Typescript does not like it when you treat the `arguments` object as an array
+            // @ts-ignore type-mismatch
+            return dispatchEvent.apply(getHost(this), arguments);
+        },
+    },
+    removeEventListener: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(type, listener, options) {
+            removeShadowRootEventListener(this, type, listener);
+        },
+    },
+    baseURI: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            return getHost(this).baseURI;
+        },
+    },
+    childNodes: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            return createStaticNodeList(shadowRootChildNodes(this));
+        },
+    },
+    cloneNode: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value() {
+            throw new Error('Disallowed method "cloneNode" on ShadowRoot.');
+        },
+    },
+    compareDocumentPosition: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(otherNode) {
+            const host = getHost(this);
+            if (this === otherNode) {
+                // "this" and "otherNode" are the same shadow root.
+                return 0;
+            }
+            else if (this.contains(otherNode)) {
+                // "otherNode" belongs to the shadow tree where "this" is the shadow root.
+                return 20; // Node.DOCUMENT_POSITION_CONTAINED_BY | Node.DOCUMENT_POSITION_FOLLOWING
+            }
+            else if (compareDocumentPosition.call(host, otherNode) & DOCUMENT_POSITION_CONTAINED_BY) {
+                // "otherNode" is in a different shadow tree contained by the shadow tree where "this" is the shadow root.
+                return 37; // Node.DOCUMENT_POSITION_DISCONNECTED | Node.DOCUMENT_POSITION_FOLLOWING | Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC
+            }
+            else {
+                // "otherNode" is in a different shadow tree that is not contained by the shadow tree where "this" is the shadow root.
+                return 35; // Node.DOCUMENT_POSITION_DISCONNECTED | Node.DOCUMENT_POSITION_PRECEDING | Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC
+            }
+        },
+    },
+    contains: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(otherNode) {
+            if (this === otherNode) {
+                return true;
+            }
+            const host = getHost(this);
+            // must be child of the host and owned by it.
+            return ((compareDocumentPosition.call(host, otherNode) & DOCUMENT_POSITION_CONTAINED_BY) !==
+                0 && isNodeOwnedBy(host, otherNode));
+        },
+    },
+    firstChild: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            const childNodes = getInternalChildNodes(this);
+            return childNodes[0] || null;
+        },
+    },
+    lastChild: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            const childNodes = getInternalChildNodes(this);
+            return childNodes[childNodes.length - 1] || null;
+        },
+    },
+    hasChildNodes: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value() {
+            const childNodes = getInternalChildNodes(this);
+            return childNodes.length > 0;
+        },
+    },
+    isConnected: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            return isConnected.call(getHost(this));
+        },
+    },
+    nextSibling: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            return null;
+        },
+    },
+    previousSibling: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            return null;
+        },
+    },
+    nodeName: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            return '#document-fragment';
+        },
+    },
+    nodeType: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            return 11; // Node.DOCUMENT_FRAGMENT_NODE
+        },
+    },
+    nodeValue: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            return null;
+        },
+    },
+    ownerDocument: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            return getHost(this).ownerDocument;
+        },
+    },
+    parentElement: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            return null;
+        },
+    },
+    parentNode: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            return null;
+        },
+    },
+    textContent: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            const childNodes = getInternalChildNodes(this);
+            let textContent = '';
+            for (let i = 0, len = childNodes.length; i < len; i += 1) {
+                const currentNode = childNodes[i];
+                if (currentNode.nodeType !== COMMENT_NODE) {
+                    textContent += getTextContent(currentNode);
+                }
+            }
+            return textContent;
+        },
+        set(v) {
+            const host = getHost(this);
+            textContextSetter.call(host, v);
+        },
+    },
+    // Since the synthetic shadow root is a detached DocumentFragment, short-circuit the getRootNode behavior
+    getRootNode: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(options) {
+            return !isUndefined(options) && isTrue(options.composed)
+                ? getHost(this).getRootNode(options)
+                : this;
+        },
+    },
 };
 const ElementPatchDescriptors = {
-  innerHTML: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      const childNodes = getInternalChildNodes(this);
-      let innerHTML = '';
-
-      for (let i = 0, len = childNodes.length; i < len; i += 1) {
-        innerHTML += getOuterHTML(childNodes[i]);
-      }
-
-      return innerHTML;
+    innerHTML: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            const childNodes = getInternalChildNodes(this);
+            let innerHTML = '';
+            for (let i = 0, len = childNodes.length; i < len; i += 1) {
+                innerHTML += getOuterHTML(childNodes[i]);
+            }
+            return innerHTML;
+        },
+        set(v) {
+            const host = getHost(this);
+            innerHTMLSetter.call(host, v);
+        },
     },
-
-    set(v) {
-      const host = getHost(this);
-      innerHTMLSetter.call(host, v);
-    }
-
-  }
 };
 const ParentNodePatchDescriptors = {
-  childElementCount: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      return this.children.length;
-    }
-
-  },
-  children: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      return createStaticHTMLCollection(ArrayFilter.call(shadowRootChildNodes(this), elm => elm instanceof Element));
-    }
-
-  },
-  firstElementChild: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      return this.children[0] || null;
-    }
-
-  },
-  lastElementChild: {
-    enumerable: true,
-    configurable: true,
-
-    get() {
-      const {
-        children
-      } = this;
-      return children.item(children.length - 1) || null;
-    }
-
-  },
-  getElementById: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value() {
-      throw new Error('Disallowed method "getElementById" on ShadowRoot.');
-    }
-
-  },
-  querySelector: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value(selectors) {
-      return shadowRootQuerySelector(this, selectors);
-    }
-
-  },
-  querySelectorAll: {
-    writable: true,
-    enumerable: true,
-    configurable: true,
-
-    value(selectors) {
-      return createStaticNodeList(shadowRootQuerySelectorAll(this, selectors));
-    }
-
-  }
+    childElementCount: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            return this.children.length;
+        },
+    },
+    children: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            return createStaticHTMLCollection(ArrayFilter.call(shadowRootChildNodes(this), (elm) => elm instanceof Element));
+        },
+    },
+    firstElementChild: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            return this.children[0] || null;
+        },
+    },
+    lastElementChild: {
+        enumerable: true,
+        configurable: true,
+        get() {
+            const { children } = this;
+            return children.item(children.length - 1) || null;
+        },
+    },
+    getElementById: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value() {
+            throw new Error('Disallowed method "getElementById" on ShadowRoot.');
+        },
+    },
+    querySelector: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(selectors) {
+            return shadowRootQuerySelector(this, selectors);
+        },
+    },
+    querySelectorAll: {
+        writable: true,
+        enumerable: true,
+        configurable: true,
+        value(selectors) {
+            return createStaticNodeList(shadowRootQuerySelectorAll(this, selectors));
+        },
+    },
 };
 assign(SyntheticShadowRootDescriptors, NodePatchDescriptors, ParentNodePatchDescriptors, ElementPatchDescriptors, ShadowRootDescriptors);
 function SyntheticShadowRoot() {
-  throw new TypeError('Illegal constructor');
+    throw new TypeError('Illegal constructor');
 }
-SyntheticShadowRoot.prototype = create(DocumentFragment.prototype, SyntheticShadowRootDescriptors); // `this.shadowRoot instanceof ShadowRoot` should evaluate to true even for synthetic shadow
-
+SyntheticShadowRoot.prototype = create(DocumentFragment.prototype, SyntheticShadowRootDescriptors);
+// `this.shadowRoot instanceof ShadowRoot` should evaluate to true even for synthetic shadow
 defineProperty(SyntheticShadowRoot, Symbol.hasInstance, {
-  value: function (object) {
-    // Technically we should walk up the entire prototype chain, but with SyntheticShadowRoot
-    // it's reasonable to assume that no one is doing any deep subclasses here.
-    return isObject(object) && !isNull(object) && (isInstanceOfNativeShadowRoot(object) || getPrototypeOf(object) === SyntheticShadowRoot.prototype);
-  }
+    value: function (object) {
+        // Technically we should walk up the entire prototype chain, but with SyntheticShadowRoot
+        // it's reasonable to assume that no one is doing any deep subclasses here.
+        return (isObject(object) &&
+            !isNull(object) &&
+            (isInstanceOfNativeShadowRoot(object) ||
+                getPrototypeOf(object) === SyntheticShadowRoot.prototype));
+    },
 });
 /**
  * This method is only intended to be used in non-production mode in IE11
@@ -2771,40 +2371,35 @@ defineProperty(SyntheticShadowRoot, Symbol.hasInstance, {
  * and a comment node that is intended to use to trick the IE11 DevTools
  * to show the content of the shadowRoot in the DOM Explorer.
  */
-
 function getIE11FakeShadowRootPlaceholder(host) {
-  const shadowRoot = getShadowRoot(host); // @ts-ignore this $$placeholder$$ is not a security issue because you must
-  // have access to the shadowRoot in order to extract the fake node, which give
-  // you access to the same childNodes of the shadowRoot, so, who cares.
-
-  let c = shadowRoot.$$placeholder$$;
-
-  if (!isUndefined(c)) {
-    return c;
-  }
-
-  const doc = getOwnerDocument(host); // @ts-ignore $$placeholder$$ is fine, read the node above.
-
-  c = shadowRoot.$$placeholder$$ = createComment.call(doc, '');
-  defineProperties(c, {
-    childNodes: {
-      get() {
-        return shadowRoot.childNodes;
-      },
-
-      enumerable: true,
-      configurable: true
-    },
-    tagName: {
-      get() {
-        return `#shadow-root (${shadowRoot.mode})`;
-      },
-
-      enumerable: true,
-      configurable: true
+    const shadowRoot = getShadowRoot(host);
+    // @ts-ignore this $$placeholder$$ is not a security issue because you must
+    // have access to the shadowRoot in order to extract the fake node, which give
+    // you access to the same childNodes of the shadowRoot, so, who cares.
+    let c = shadowRoot.$$placeholder$$;
+    if (!isUndefined(c)) {
+        return c;
     }
-  });
-  return c;
+    const doc = getOwnerDocument(host);
+    // @ts-ignore $$placeholder$$ is fine, read the node above.
+    c = shadowRoot.$$placeholder$$ = createComment.call(doc, '');
+    defineProperties(c, {
+        childNodes: {
+            get() {
+                return shadowRoot.childNodes;
+            },
+            enumerable: true,
+            configurable: true,
+        },
+        tagName: {
+            get() {
+                return `#shadow-root (${shadowRoot.mode})`;
+            },
+            enumerable: true,
+            configurable: true,
+        },
+    });
+    return c;
 }
 
 /*
@@ -2814,54 +2409,53 @@ function getIE11FakeShadowRootPlaceholder(host) {
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 function pathComposer(startNode, composed) {
-  const composedPath = [];
-  let startRoot;
-
-  if (startNode instanceof Window) {
-    startRoot = startNode;
-  } else if (startNode instanceof _Node) {
-    startRoot = startNode.getRootNode();
-  } else {
-    return composedPath;
-  }
-
-  let current = startNode;
-
-  while (!isNull(current)) {
-    composedPath.push(current);
-
-    if (current instanceof Element || current instanceof Text) {
-      const assignedSlot = current.assignedSlot;
-
-      if (!isNull(assignedSlot)) {
-        current = assignedSlot;
-      } else {
-        current = current.parentNode;
-      }
-    } else if ((isSyntheticShadowRoot(current) || isInstanceOfNativeShadowRoot(current)) && (composed || current !== startRoot)) {
-      current = current.host;
-    } else if (current instanceof _Node) {
-      current = current.parentNode;
-    } else {
-      // could be Window
-      current = null;
+    const composedPath = [];
+    let startRoot;
+    if (startNode instanceof Window) {
+        startRoot = startNode;
     }
-  }
-
-  let doc;
-
-  if (startNode instanceof Window) {
-    doc = startNode.document;
-  } else {
-    doc = getOwnerDocument(startNode);
-  } // event composedPath includes window when startNode's ownerRoot is document
-
-
-  if (composedPath[composedPath.length - 1] === doc) {
-    composedPath.push(window);
-  }
-
-  return composedPath;
+    else if (startNode instanceof _Node) {
+        startRoot = startNode.getRootNode();
+    }
+    else {
+        return composedPath;
+    }
+    let current = startNode;
+    while (!isNull(current)) {
+        composedPath.push(current);
+        if (current instanceof Element || current instanceof Text) {
+            const assignedSlot = current.assignedSlot;
+            if (!isNull(assignedSlot)) {
+                current = assignedSlot;
+            }
+            else {
+                current = current.parentNode;
+            }
+        }
+        else if ((isSyntheticShadowRoot(current) || isInstanceOfNativeShadowRoot(current)) &&
+            (composed || current !== startRoot)) {
+            current = current.host;
+        }
+        else if (current instanceof _Node) {
+            current = current.parentNode;
+        }
+        else {
+            // could be Window
+            current = null;
+        }
+    }
+    let doc;
+    if (startNode instanceof Window) {
+        doc = startNode.document;
+    }
+    else {
+        doc = getOwnerDocument(startNode);
+    }
+    // event composedPath includes window when startNode's ownerRoot is document
+    if (composedPath[composedPath.length - 1] === doc) {
+        composedPath.push(window);
+    }
+    return composedPath;
 }
 
 /*
@@ -2879,32 +2473,26 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
-
 function retarget(refNode, path) {
-  if (isNull(refNode)) {
+    if (isNull(refNode)) {
+        return null;
+    }
+    // If ANCESTOR's root is not a shadow root or ANCESTOR's root is BASE's
+    // shadow-including inclusive ancestor, return ANCESTOR.
+    const refNodePath = pathComposer(refNode, true);
+    const p$ = path;
+    for (let i = 0, ancestor, lastRoot, root, rootIdx; i < p$.length; i++) {
+        ancestor = p$[i];
+        root = ancestor instanceof Window ? ancestor : ancestor.getRootNode();
+        if (root !== lastRoot) {
+            rootIdx = refNodePath.indexOf(root);
+            lastRoot = root;
+        }
+        if (!isSyntheticShadowRoot(root) || (!isUndefined(rootIdx) && rootIdx > -1)) {
+            return ancestor;
+        }
+    }
     return null;
-  } // If ANCESTOR's root is not a shadow root or ANCESTOR's root is BASE's
-  // shadow-including inclusive ancestor, return ANCESTOR.
-
-
-  const refNodePath = pathComposer(refNode, true);
-  const p$ = path;
-
-  for (let i = 0, ancestor, lastRoot, root, rootIdx; i < p$.length; i++) {
-    ancestor = p$[i];
-    root = ancestor instanceof Window ? ancestor : ancestor.getRootNode();
-
-    if (root !== lastRoot) {
-      rootIdx = refNodePath.indexOf(root);
-      lastRoot = root;
-    }
-
-    if (!isSyntheticShadowRoot(root) || !isUndefined(rootIdx) && rootIdx > -1) {
-      return ancestor;
-    }
-  }
-
-  return null;
 }
 
 /*
@@ -2914,13 +2502,11 @@ function retarget(refNode, path) {
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 function fauxElementFromPoint(context, doc, left, top) {
-  const element = elementFromPoint.call(doc, left, top);
-
-  if (isNull(element)) {
-    return element;
-  }
-
-  return retarget(context, pathComposer(element, true));
+    const element = elementFromPoint.call(doc, left, top);
+    if (isNull(element)) {
+        return element;
+    }
+    return retarget(context, pathComposer(element, true));
 }
 
 /*
@@ -2929,46 +2515,37 @@ function fauxElementFromPoint(context, doc, left, top) {
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
 function elemFromPoint(left, top) {
-  return fauxElementFromPoint(this, this, left, top);
+    return fauxElementFromPoint(this, this, left, top);
 }
-
 Document.prototype.elementFromPoint = elemFromPoint;
-
 function elemsFromPoint(left, top) {
-  return fauxElementsFromPoint(this, this, left, top);
+    return fauxElementsFromPoint(this, this, left, top);
 }
-
-Document.prototype.elementsFromPoint = elemsFromPoint; // Go until we reach to top of the LWC tree
-
+Document.prototype.elementsFromPoint = elemsFromPoint;
+// Go until we reach to top of the LWC tree
 defineProperty(Document.prototype, 'activeElement', {
-  get() {
-    let node = DocumentPrototypeActiveElement.call(this);
-
-    if (isNull(node)) {
-      return node;
-    }
-
-    while (!isUndefined(getNodeOwnerKey(node))) {
-      node = parentElementGetter.call(node);
-
-      if (isNull(node)) {
-        return null;
-      }
-    }
-
-    if (node.tagName === 'HTML') {
-      // IE 11. Active element should never be html element
-      node = this.body;
-    }
-
-    return node;
-  },
-
-  enumerable: true,
-  configurable: true
-}); // The following patched methods hide shadowed elements from global
+    get() {
+        let node = DocumentPrototypeActiveElement.call(this);
+        if (isNull(node)) {
+            return node;
+        }
+        while (!isUndefined(getNodeOwnerKey(node))) {
+            node = parentElementGetter.call(node);
+            if (isNull(node)) {
+                return null;
+            }
+        }
+        if (node.tagName === 'HTML') {
+            // IE 11. Active element should never be html element
+            node = this.body;
+        }
+        return node;
+    },
+    enumerable: true,
+    configurable: true,
+});
+// The following patched methods hide shadowed elements from global
 // traversing mechanisms. They are simplified for performance reasons to
 // filter by ownership and do not account for slotted elements. This
 // compromise is fine for our synthetic shadow dom because root elements
@@ -2977,95 +2554,94 @@ defineProperty(Document.prototype, 'activeElement', {
 // static HTMLCollection or static NodeList. We decided that this compromise
 // is not a big problem considering the amount of code that is relying on
 // the liveliness of these results are rare.
-
 defineProperty(Document.prototype, 'getElementById', {
-  value() {
-    const elm = getElementById.apply(this, ArraySlice.call(arguments));
-
-    if (isNull(elm)) {
-      return null;
-    } // TODO [#1222]: remove global bypass
-
-
-    return isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm) ? elm : null;
-  },
-
-  writable: true,
-  enumerable: true,
-  configurable: true
+    value() {
+        const elm = getElementById.apply(this, ArraySlice.call(arguments));
+        if (isNull(elm)) {
+            return null;
+        }
+        // TODO [#1222]: remove global bypass
+        return isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm) ? elm : null;
+    },
+    writable: true,
+    enumerable: true,
+    configurable: true,
 });
 defineProperty(Document.prototype, 'querySelector', {
-  value() {
-    const elements = arrayFromCollection(querySelectorAll.apply(this, ArraySlice.call(arguments)));
-    const filtered = ArrayFind.call(elements, // TODO [#1222]: remove global bypass
-    elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm));
-    return !isUndefined(filtered) ? filtered : null;
-  },
-
-  writable: true,
-  enumerable: true,
-  configurable: true
+    value() {
+        const elements = arrayFromCollection(querySelectorAll.apply(this, ArraySlice.call(arguments)));
+        const filtered = ArrayFind.call(elements, 
+        // TODO [#1222]: remove global bypass
+        (elm) => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm));
+        return !isUndefined(filtered) ? filtered : null;
+    },
+    writable: true,
+    enumerable: true,
+    configurable: true,
 });
 defineProperty(Document.prototype, 'querySelectorAll', {
-  value() {
-    const elements = arrayFromCollection(querySelectorAll.apply(this, ArraySlice.call(arguments)));
-    const filtered = ArrayFilter.call(elements, // TODO [#1222]: remove global bypass
-    elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm));
-    return createStaticNodeList(filtered);
-  },
-
-  writable: true,
-  enumerable: true,
-  configurable: true
+    value() {
+        const elements = arrayFromCollection(querySelectorAll.apply(this, ArraySlice.call(arguments)));
+        const filtered = ArrayFilter.call(elements, 
+        // TODO [#1222]: remove global bypass
+        (elm) => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm));
+        return createStaticNodeList(filtered);
+    },
+    writable: true,
+    enumerable: true,
+    configurable: true,
 });
 defineProperty(Document.prototype, 'getElementsByClassName', {
-  value() {
-    const elements = arrayFromCollection(getElementsByClassName.apply(this, ArraySlice.call(arguments)));
-    const filtered = ArrayFilter.call(elements, // TODO [#1222]: remove global bypass
-    elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm));
-    return createStaticHTMLCollection(filtered);
-  },
-
-  writable: true,
-  enumerable: true,
-  configurable: true
+    value() {
+        const elements = arrayFromCollection(getElementsByClassName.apply(this, ArraySlice.call(arguments)));
+        const filtered = ArrayFilter.call(elements, 
+        // TODO [#1222]: remove global bypass
+        (elm) => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm));
+        return createStaticHTMLCollection(filtered);
+    },
+    writable: true,
+    enumerable: true,
+    configurable: true,
 });
 defineProperty(Document.prototype, 'getElementsByTagName', {
-  value() {
-    const elements = arrayFromCollection(getElementsByTagName.apply(this, ArraySlice.call(arguments)));
-    const filtered = ArrayFilter.call(elements, // TODO [#1222]: remove global bypass
-    elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm));
-    return createStaticHTMLCollection(filtered);
-  },
-
-  writable: true,
-  enumerable: true,
-  configurable: true
+    value() {
+        const elements = arrayFromCollection(getElementsByTagName.apply(this, ArraySlice.call(arguments)));
+        const filtered = ArrayFilter.call(elements, 
+        // TODO [#1222]: remove global bypass
+        (elm) => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm));
+        return createStaticHTMLCollection(filtered);
+    },
+    writable: true,
+    enumerable: true,
+    configurable: true,
 });
 defineProperty(Document.prototype, 'getElementsByTagNameNS', {
-  value() {
-    const elements = arrayFromCollection(getElementsByTagNameNS.apply(this, ArraySlice.call(arguments)));
-    const filtered = ArrayFilter.call(elements, // TODO [#1222]: remove global bypass
-    elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm));
-    return createStaticHTMLCollection(filtered);
-  },
-
-  writable: true,
-  enumerable: true,
-  configurable: true
+    value() {
+        const elements = arrayFromCollection(getElementsByTagNameNS.apply(this, ArraySlice.call(arguments)));
+        const filtered = ArrayFilter.call(elements, 
+        // TODO [#1222]: remove global bypass
+        (elm) => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm));
+        return createStaticHTMLCollection(filtered);
+    },
+    writable: true,
+    enumerable: true,
+    configurable: true,
 });
-defineProperty( // In Firefox v57 and lower, getElementsByName is defined on HTMLDocument.prototype
-getOwnPropertyDescriptor(HTMLDocument.prototype, 'getElementsByName') ? HTMLDocument.prototype : Document.prototype, 'getElementsByName', {
-  value() {
-    const elements = arrayFromCollection(getElementsByName.apply(this, ArraySlice.call(arguments)));
-    const filtered = ArrayFilter.call(elements, // TODO [#1222]: remove global bypass
-    elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm));
-    return createStaticNodeList(filtered);
-  },
-
-  writable: true,
-  enumerable: true,
-  configurable: true
+defineProperty(
+// In Firefox v57 and lower, getElementsByName is defined on HTMLDocument.prototype
+getOwnPropertyDescriptor(HTMLDocument.prototype, 'getElementsByName')
+    ? HTMLDocument.prototype
+    : Document.prototype, 'getElementsByName', {
+    value() {
+        const elements = arrayFromCollection(getElementsByName.apply(this, ArraySlice.call(arguments)));
+        const filtered = ArrayFilter.call(elements, 
+        // TODO [#1222]: remove global bypass
+        (elm) => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(elm));
+        return createStaticNodeList(filtered);
+    },
+    writable: true,
+    enumerable: true,
+    configurable: true,
 });
 
 /*
@@ -3075,9 +2651,9 @@ getOwnPropertyDescriptor(HTMLDocument.prototype, 'getElementsByName') ? HTMLDocu
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 Object.defineProperty(window, 'ShadowRoot', {
-  value: SyntheticShadowRoot,
-  configurable: true,
-  writable: true
+    value: SyntheticShadowRoot,
+    configurable: true,
+    writable: true,
 });
 
 /*
@@ -3088,20 +2664,19 @@ Object.defineProperty(window, 'ShadowRoot', {
  */
 const composedDescriptor = Object.getOwnPropertyDescriptor(Event.prototype, 'composed');
 function detect$3() {
-  if (!composedDescriptor) {
-    // No need to apply this polyfill if this client completely lacks
-    // support for the composed property.
-    return false;
-  } // Assigning a throwaway click event here to suppress a ts error when we
-  // pass clickEvent into the composed getter below. The error is:
-  // [ts] Variable 'clickEvent' is used before being assigned.
-
-
-  let clickEvent = new Event('click');
-  const button = document.createElement('button');
-  button.addEventListener('click', event => clickEvent = event);
-  button.click();
-  return !composedDescriptor.get.call(clickEvent);
+    if (!composedDescriptor) {
+        // No need to apply this polyfill if this client completely lacks
+        // support for the composed property.
+        return false;
+    }
+    // Assigning a throwaway click event here to suppress a ts error when we
+    // pass clickEvent into the composed getter below. The error is:
+    // [ts] Variable 'clickEvent' is used before being assigned.
+    let clickEvent = new Event('click');
+    const button = document.createElement('button');
+    button.addEventListener('click', (event) => (clickEvent = event));
+    button.click();
+    return !composedDescriptor.get.call(clickEvent);
 }
 
 /*
@@ -3111,29 +2686,25 @@ function detect$3() {
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const originalClickDescriptor = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'click');
-
 function handleClick(event) {
-  Object.defineProperty(event, 'composed', {
-    configurable: true,
-    enumerable: true,
-
-    get() {
-      return true;
-    }
-
-  });
+    Object.defineProperty(event, 'composed', {
+        configurable: true,
+        enumerable: true,
+        get() {
+            return true;
+        },
+    });
 }
-
 function apply$3() {
-  HTMLElement.prototype.click = function () {
-    addEventListener.call(this, 'click', handleClick);
-
-    try {
-      originalClickDescriptor.value.call(this);
-    } finally {
-      removeEventListener.call(this, 'click', handleClick);
-    }
-  };
+    HTMLElement.prototype.click = function () {
+        addEventListener.call(this, 'click', handleClick);
+        try {
+            originalClickDescriptor.value.call(this);
+        }
+        finally {
+            removeEventListener.call(this, 'click', handleClick);
+        }
+    };
 }
 
 /*
@@ -3142,9 +2713,8 @@ function apply$3() {
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
 if (detect$3()) {
-  apply$3();
+    apply$3();
 }
 
 /*
@@ -3154,9 +2724,7 @@ if (detect$3()) {
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 function detect$2() {
-  return new Event('test', {
-    composed: true
-  }).composed !== true;
+    return new Event('test', { composed: true }).composed !== true;
 }
 
 /*
@@ -3166,134 +2734,124 @@ function detect$2() {
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 function apply$2() {
-  // https://github.com/w3c/webcomponents/issues/513#issuecomment-224183937
-  const composedEvents = assign(create(null), {
-    beforeinput: 1,
-    blur: 1,
-    click: 1,
-    compositionend: 1,
-    compositionstart: 1,
-    compositionupdate: 1,
-    copy: 1,
-    cut: 1,
-    dblclick: 1,
-    DOMActivate: 1,
-    DOMFocusIn: 1,
-    DOMFocusOut: 1,
-    drag: 1,
-    dragend: 1,
-    dragenter: 1,
-    dragleave: 1,
-    dragover: 1,
-    dragstart: 1,
-    drop: 1,
-    focus: 1,
-    focusin: 1,
-    focusout: 1,
-    gotpointercapture: 1,
-    input: 1,
-    keydown: 1,
-    keypress: 1,
-    keyup: 1,
-    lostpointercapture: 1,
-    mousedown: 1,
-    mouseenter: 1,
-    mouseleave: 1,
-    mousemove: 1,
-    mouseout: 1,
-    mouseover: 1,
-    mouseup: 1,
-    paste: 1,
-    pointercancel: 1,
-    pointerdown: 1,
-    pointerenter: 1,
-    pointerleave: 1,
-    pointermove: 1,
-    pointerout: 1,
-    pointerover: 1,
-    pointerup: 1,
-    touchcancel: 1,
-    touchend: 1,
-    touchmove: 1,
-    touchstart: 1,
-    wheel: 1
-  });
-  const EventConstructor = Event; // Patch Event constructor to add the composed property on events created via new Event.
+    // https://github.com/w3c/webcomponents/issues/513#issuecomment-224183937
+    const composedEvents = assign(create(null), {
+        beforeinput: 1,
+        blur: 1,
+        click: 1,
+        compositionend: 1,
+        compositionstart: 1,
+        compositionupdate: 1,
+        copy: 1,
+        cut: 1,
+        dblclick: 1,
+        DOMActivate: 1,
+        DOMFocusIn: 1,
+        DOMFocusOut: 1,
+        drag: 1,
+        dragend: 1,
+        dragenter: 1,
+        dragleave: 1,
+        dragover: 1,
+        dragstart: 1,
+        drop: 1,
+        focus: 1,
+        focusin: 1,
+        focusout: 1,
+        gotpointercapture: 1,
+        input: 1,
+        keydown: 1,
+        keypress: 1,
+        keyup: 1,
+        lostpointercapture: 1,
+        mousedown: 1,
+        mouseenter: 1,
+        mouseleave: 1,
+        mousemove: 1,
+        mouseout: 1,
+        mouseover: 1,
+        mouseup: 1,
+        paste: 1,
+        pointercancel: 1,
+        pointerdown: 1,
+        pointerenter: 1,
+        pointerleave: 1,
+        pointermove: 1,
+        pointerout: 1,
+        pointerover: 1,
+        pointerup: 1,
+        touchcancel: 1,
+        touchend: 1,
+        touchmove: 1,
+        touchstart: 1,
+        wheel: 1,
+    });
+    const EventConstructor = Event;
+    // Patch Event constructor to add the composed property on events created via new Event.
+    function PatchedEvent(type, eventInitDict) {
+        const event = new EventConstructor(type, eventInitDict);
+        const isComposed = !!(eventInitDict && eventInitDict.composed);
+        Object.defineProperties(event, {
+            composed: {
+                get() {
+                    return isComposed;
+                },
+                configurable: true,
+                enumerable: true,
+            },
+        });
+        return event;
+    }
+    PatchedEvent.prototype = EventConstructor.prototype;
+    PatchedEvent.AT_TARGET = EventConstructor.AT_TARGET;
+    PatchedEvent.BUBBLING_PHASE = EventConstructor.BUBBLING_PHASE;
+    PatchedEvent.CAPTURING_PHASE = EventConstructor.CAPTURING_PHASE;
+    PatchedEvent.NONE = EventConstructor.NONE;
+    window.Event = PatchedEvent;
+    // Patch the Event prototype to add the composed property on user agent dispatched event.
+    Object.defineProperties(Event.prototype, {
+        composed: {
+            get() {
+                const { type } = this;
+                return composedEvents[type] === 1;
+            },
+            configurable: true,
+            enumerable: true,
+        },
+    });
+}
 
-  function PatchedEvent(type, eventInitDict) {
-    const event = new EventConstructor(type, eventInitDict);
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+if (detect$2()) {
+    apply$2();
+}
+
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const CustomEventConstructor = CustomEvent;
+function PatchedCustomEvent(type, eventInitDict) {
+    const event = new CustomEventConstructor(type, eventInitDict);
     const isComposed = !!(eventInitDict && eventInitDict.composed);
     Object.defineProperties(event, {
-      composed: {
-        get() {
-          return isComposed;
+        composed: {
+            get() {
+                return isComposed;
+            },
+            configurable: true,
+            enumerable: true,
         },
-
-        configurable: true,
-        enumerable: true
-      }
     });
     return event;
-  }
-
-  PatchedEvent.prototype = EventConstructor.prototype;
-  PatchedEvent.AT_TARGET = EventConstructor.AT_TARGET;
-  PatchedEvent.BUBBLING_PHASE = EventConstructor.BUBBLING_PHASE;
-  PatchedEvent.CAPTURING_PHASE = EventConstructor.CAPTURING_PHASE;
-  PatchedEvent.NONE = EventConstructor.NONE;
-  window.Event = PatchedEvent; // Patch the Event prototype to add the composed property on user agent dispatched event.
-
-  Object.defineProperties(Event.prototype, {
-    composed: {
-      get() {
-        const {
-          type
-        } = this;
-        return composedEvents[type] === 1;
-      },
-
-      configurable: true,
-      enumerable: true
-    }
-  });
 }
-
-/*
- * Copyright (c) 2018, salesforce.com, inc.
- * All rights reserved.
- * SPDX-License-Identifier: MIT
- * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
- */
-
-if (detect$2()) {
-  apply$2();
-}
-
-/*
- * Copyright (c) 2018, salesforce.com, inc.
- * All rights reserved.
- * SPDX-License-Identifier: MIT
- * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
- */
-
-const CustomEventConstructor = CustomEvent;
-
-function PatchedCustomEvent(type, eventInitDict) {
-  const event = new CustomEventConstructor(type, eventInitDict);
-  const isComposed = !!(eventInitDict && eventInitDict.composed);
-  Object.defineProperties(event, {
-    composed: {
-      get() {
-        return isComposed;
-      },
-
-      configurable: true,
-      enumerable: true
-    }
-  });
-  return event;
-}
-
 PatchedCustomEvent.prototype = CustomEventConstructor.prototype;
 window.CustomEvent = PatchedCustomEvent;
 
@@ -3303,27 +2861,23 @@ window.CustomEvent = PatchedCustomEvent;
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
 if (typeof ClipboardEvent !== 'undefined') {
-  const isComposedType = assign(create(null), {
-    copy: 1,
-    cut: 1,
-    paste: 1
-  }); // Patch the prototype to override the composed property on user-agent dispatched events
-
-  defineProperties(ClipboardEvent.prototype, {
-    composed: {
-      get() {
-        const {
-          type
-        } = this;
-        return isComposedType[type] === 1;
-      },
-
-      configurable: true,
-      enumerable: true
-    }
-  });
+    const isComposedType = assign(create(null), {
+        copy: 1,
+        cut: 1,
+        paste: 1,
+    });
+    // Patch the prototype to override the composed property on user-agent dispatched events
+    defineProperties(ClipboardEvent.prototype, {
+        composed: {
+            get() {
+                const { type } = this;
+                return isComposedType[type] === 1;
+            },
+            configurable: true,
+            enumerable: true,
+        },
+    });
 }
 
 /*
@@ -3333,8 +2887,8 @@ if (typeof ClipboardEvent !== 'undefined') {
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 function detect$1() {
-  // Note: when using this in mobile apps, we might have a DOM that does not support iframes.
-  return typeof HTMLIFrameElement !== 'undefined';
+    // Note: when using this in mobile apps, we might have a DOM that does not support iframes.
+    return typeof HTMLIFrameElement !== 'undefined';
 }
 
 /*
@@ -3344,110 +2898,88 @@ function detect$1() {
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 function apply$1() {
-  // the iframe property descriptor for `contentWindow` should always be available, otherwise this method should never be called
-  const desc = getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'contentWindow');
-  const {
-    get: originalGetter
-  } = desc;
-
-  desc.get = function () {
-    const original = originalGetter.call(this); // If the original iframe element is not a keyed node, then do not wrap it
-
-    if (isNull(original) || isUndefined(getNodeOwnerKey(this))) {
-      return original;
-    } // only if the element is an iframe inside a shadowRoot, we care about this problem
-    // because in that case, the code that is accessing the iframe, is very likely code
-    // compiled with proxy-compat transformation. It is true that other code without those
-    // transformations might also access an iframe from within a shadowRoot, but in that,
-    // case, which is more rare, we still return the wrapper, and it should work the same,
-    // this part is just an optimization.
-
-
-    return wrapIframeWindow(original);
-  };
-
-  defineProperty(HTMLIFrameElement.prototype, 'contentWindow', desc);
+    // the iframe property descriptor for `contentWindow` should always be available, otherwise this method should never be called
+    const desc = getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'contentWindow');
+    const { get: originalGetter } = desc;
+    desc.get = function () {
+        const original = originalGetter.call(this);
+        // If the original iframe element is not a keyed node, then do not wrap it
+        if (isNull(original) || isUndefined(getNodeOwnerKey(this))) {
+            return original;
+        }
+        // only if the element is an iframe inside a shadowRoot, we care about this problem
+        // because in that case, the code that is accessing the iframe, is very likely code
+        // compiled with proxy-compat transformation. It is true that other code without those
+        // transformations might also access an iframe from within a shadowRoot, but in that,
+        // case, which is more rare, we still return the wrapper, and it should work the same,
+        // this part is just an optimization.
+        return wrapIframeWindow(original);
+    };
+    defineProperty(HTMLIFrameElement.prototype, 'contentWindow', desc);
 }
-
 function wrapIframeWindow(win) {
-  return {
-    addEventListener() {
-      // Typescript does not like it when you treat the `arguments` object as an array
-      // @ts-ignore type-mismatch
-      return win.addEventListener.apply(win, arguments);
-    },
-
-    blur() {
-      // Typescript does not like it when you treat the `arguments` object as an array
-      // @ts-ignore type-mismatch
-      return win.blur.apply(win, arguments);
-    },
-
-    close() {
-      // Typescript does not like it when you treat the `arguments` object as an array
-      // @ts-ignore type-mismatch
-      return win.close.apply(win, arguments);
-    },
-
-    focus() {
-      // Typescript does not like it when you treat the `arguments` object as an array
-      // @ts-ignore type-mismatch
-      return win.focus.apply(win, arguments);
-    },
-
-    postMessage() {
-      // Typescript does not like it when you treat the `arguments` object as an array
-      // @ts-ignore type-mismatch
-      return win.postMessage.apply(win, arguments);
-    },
-
-    removeEventListener() {
-      // Typescript does not like it when you treat the `arguments` object as an array
-      // @ts-ignore type-mismatch
-      return win.removeEventListener.apply(win, arguments);
-    },
-
-    get closed() {
-      return win.closed;
-    },
-
-    get frames() {
-      return win.frames;
-    },
-
-    get length() {
-      return win.length;
-    },
-
-    get location() {
-      return win.location;
-    },
-
-    set location(value) {
-      win.location = value;
-    },
-
-    get opener() {
-      return win.opener;
-    },
-
-    get parent() {
-      return win.parent;
-    },
-
-    get self() {
-      return win.self;
-    },
-
-    get top() {
-      return win.top;
-    },
-
-    get window() {
-      return win.window;
-    }
-
-  }; // this is limited
+    return {
+        addEventListener() {
+            // Typescript does not like it when you treat the `arguments` object as an array
+            // @ts-ignore type-mismatch
+            return win.addEventListener.apply(win, arguments);
+        },
+        blur() {
+            // Typescript does not like it when you treat the `arguments` object as an array
+            // @ts-ignore type-mismatch
+            return win.blur.apply(win, arguments);
+        },
+        close() {
+            // Typescript does not like it when you treat the `arguments` object as an array
+            // @ts-ignore type-mismatch
+            return win.close.apply(win, arguments);
+        },
+        focus() {
+            // Typescript does not like it when you treat the `arguments` object as an array
+            // @ts-ignore type-mismatch
+            return win.focus.apply(win, arguments);
+        },
+        postMessage() {
+            // Typescript does not like it when you treat the `arguments` object as an array
+            // @ts-ignore type-mismatch
+            return win.postMessage.apply(win, arguments);
+        },
+        removeEventListener() {
+            // Typescript does not like it when you treat the `arguments` object as an array
+            // @ts-ignore type-mismatch
+            return win.removeEventListener.apply(win, arguments);
+        },
+        get closed() {
+            return win.closed;
+        },
+        get frames() {
+            return win.frames;
+        },
+        get length() {
+            return win.length;
+        },
+        get location() {
+            return win.location;
+        },
+        set location(value) {
+            win.location = value;
+        },
+        get opener() {
+            return win.opener;
+        },
+        get parent() {
+            return win.parent;
+        },
+        get self() {
+            return win.self;
+        },
+        get top() {
+            return win.top;
+        },
+        get window() {
+            return win.window;
+        },
+    }; // this is limited
 }
 
 /*
@@ -3456,9 +2988,8 @@ function wrapIframeWindow(win) {
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
 if (detect$1()) {
-  apply$1();
+    apply$1();
 }
 
 /*
@@ -3468,72 +2999,55 @@ if (detect$1()) {
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 const OriginalMutationObserver = MutationObserver;
-const {
-  disconnect: originalDisconnect,
-  observe: originalObserve,
-  takeRecords: originalTakeRecords
-} = OriginalMutationObserver.prototype; // Internal fields to maintain relationships
-
+const { disconnect: originalDisconnect, observe: originalObserve, takeRecords: originalTakeRecords, } = OriginalMutationObserver.prototype;
+// Internal fields to maintain relationships
 const wrapperLookupField = '$$lwcObserverCallbackWrapper$$';
 const observerLookupField = '$$lwcNodeObservers$$';
 const observerToNodesMap = new WeakMap();
-
 function getNodeObservers(node) {
-  return node[observerLookupField];
+    return node[observerLookupField];
 }
-
 function setNodeObservers(node, observers) {
-  node[observerLookupField] = observers;
+    node[observerLookupField] = observers;
 }
 /**
  * Retarget the mutation record's target value to its shadowRoot
  * @param {MutationRecord} originalRecord
  */
-
-
 function retargetMutationRecord(originalRecord) {
-  const {
-    addedNodes,
-    removedNodes,
-    target,
-    type
-  } = originalRecord;
-  const retargetedRecord = create(MutationRecord.prototype);
-  defineProperties(retargetedRecord, {
-    addedNodes: {
-      get() {
-        return addedNodes;
-      },
-
-      enumerable: true,
-      configurable: true
-    },
-    removedNodes: {
-      get() {
-        return removedNodes;
-      },
-
-      enumerable: true,
-      configurable: true
-    },
-    type: {
-      get() {
-        return type;
-      },
-
-      enumerable: true,
-      configurable: true
-    },
-    target: {
-      get() {
-        return target.shadowRoot;
-      },
-
-      enumerable: true,
-      configurable: true
-    }
-  });
-  return retargetedRecord;
+    const { addedNodes, removedNodes, target, type } = originalRecord;
+    const retargetedRecord = create(MutationRecord.prototype);
+    defineProperties(retargetedRecord, {
+        addedNodes: {
+            get() {
+                return addedNodes;
+            },
+            enumerable: true,
+            configurable: true,
+        },
+        removedNodes: {
+            get() {
+                return removedNodes;
+            },
+            enumerable: true,
+            configurable: true,
+        },
+        type: {
+            get() {
+                return type;
+            },
+            enumerable: true,
+            configurable: true,
+        },
+        target: {
+            get() {
+                return target.shadowRoot;
+            },
+            enumerable: true,
+            configurable: true,
+        },
+    });
+    return retargetedRecord;
 }
 /**
  * Utility to identify if a target node is being observed by the given observer
@@ -3541,23 +3055,18 @@ function retargetMutationRecord(originalRecord) {
  * @param {MutationObserver} observer
  * @param {Node} target
  */
-
-
 function isQualifiedObserver(observer, target) {
-  let parentNode = target;
-
-  while (!isNull(parentNode)) {
-    const parentNodeObservers = getNodeObservers(parentNode);
-
-    if (!isUndefined(parentNodeObservers) && (parentNodeObservers[0] === observer || // perf optimization to check for the first item is a match
-    ArrayIndexOf.call(parentNodeObservers, observer) !== -1)) {
-      return true;
+    let parentNode = target;
+    while (!isNull(parentNode)) {
+        const parentNodeObservers = getNodeObservers(parentNode);
+        if (!isUndefined(parentNodeObservers) &&
+            (parentNodeObservers[0] === observer || // perf optimization to check for the first item is a match
+                ArrayIndexOf.call(parentNodeObservers, observer) !== -1)) {
+            return true;
+        }
+        parentNode = parentNode.parentNode;
     }
-
-    parentNode = parentNode.parentNode;
-  }
-
-  return false;
+    return false;
 }
 /**
  * This function provides a shadow dom compliant filtered view of mutation records for a given observer.
@@ -3568,86 +3077,78 @@ function isQualifiedObserver(observer, target) {
  * @param {MutationRecords[]} mutations
  * @param {MutationObserver} observer
  */
-
-
 function filterMutationRecords(mutations, observer) {
-  return ArrayReduce.call(mutations, (filteredSet, record) => {
-    const {
-      target,
-      addedNodes,
-      removedNodes,
-      type
-    } = record; // If target is an lwc host,
-    // Determine if the mutations affected the host or the shadowRoot
-    // Mutations affecting host: changes to slot content
-    // Mutations affecting shadowRoot: changes to template content
-
-    if (type === 'childList' && !isUndefined(getNodeKey(target))) {
-      // In case of added nodes, we can climb up the tree and determine eligibility
-      if (addedNodes.length > 0) {
-        // Optimization: Peek in and test one node to decide if the MutationRecord qualifies
-        // The remaining nodes in this MutationRecord will have the same ownerKey
-        const sampleNode = addedNodes[0];
-
-        if (isQualifiedObserver(observer, sampleNode)) {
-          // If the target was being observed, then return record as-is
-          // this will be the case for slot content
-          const nodeObservers = getNodeObservers(target);
-
-          if (nodeObservers && (nodeObservers[0] === observer || ArrayIndexOf.call(nodeObservers, observer) !== -1)) {
-            ArrayPush.call(filteredSet, record);
-          } else {
-            // else, must be observing the shadowRoot
-            ArrayPush.call(filteredSet, retargetMutationRecord(record));
-          }
+    return ArrayReduce.call(mutations, (filteredSet, record) => {
+        const { target, addedNodes, removedNodes, type } = record;
+        // If target is an lwc host,
+        // Determine if the mutations affected the host or the shadowRoot
+        // Mutations affecting host: changes to slot content
+        // Mutations affecting shadowRoot: changes to template content
+        if (type === 'childList' && !isUndefined(getNodeKey(target))) {
+            // In case of added nodes, we can climb up the tree and determine eligibility
+            if (addedNodes.length > 0) {
+                // Optimization: Peek in and test one node to decide if the MutationRecord qualifies
+                // The remaining nodes in this MutationRecord will have the same ownerKey
+                const sampleNode = addedNodes[0];
+                if (isQualifiedObserver(observer, sampleNode)) {
+                    // If the target was being observed, then return record as-is
+                    // this will be the case for slot content
+                    const nodeObservers = getNodeObservers(target);
+                    if (nodeObservers &&
+                        (nodeObservers[0] === observer ||
+                            ArrayIndexOf.call(nodeObservers, observer) !== -1)) {
+                        ArrayPush.call(filteredSet, record);
+                    }
+                    else {
+                        // else, must be observing the shadowRoot
+                        ArrayPush.call(filteredSet, retargetMutationRecord(record));
+                    }
+                }
+            }
+            else {
+                // In the case of removed nodes, climbing the tree is not an option as the nodes are disconnected
+                // We can only check if either the host or shadow root was observed and qualify the record
+                const shadowRoot = target.shadowRoot;
+                const sampleNode = removedNodes[0];
+                if (getNodeNearestOwnerKey(target) === getNodeNearestOwnerKey(sampleNode) && // trickery: sampleNode is slot content
+                    isQualifiedObserver(observer, target) // use target as a close enough reference to climb up
+                ) {
+                    ArrayPush.call(filteredSet, record);
+                }
+                else if (shadowRoot) {
+                    const shadowRootObservers = getNodeObservers(shadowRoot);
+                    if (shadowRootObservers &&
+                        (shadowRootObservers[0] === observer ||
+                            ArrayIndexOf.call(shadowRootObservers, observer) !== -1)) {
+                        ArrayPush.call(filteredSet, retargetMutationRecord(record));
+                    }
+                }
+            }
         }
-      } else {
-        // In the case of removed nodes, climbing the tree is not an option as the nodes are disconnected
-        // We can only check if either the host or shadow root was observed and qualify the record
-        const shadowRoot = target.shadowRoot;
-        const sampleNode = removedNodes[0];
-
-        if (getNodeNearestOwnerKey(target) === getNodeNearestOwnerKey(sampleNode) && // trickery: sampleNode is slot content
-        isQualifiedObserver(observer, target) // use target as a close enough reference to climb up
-        ) {
-          ArrayPush.call(filteredSet, record);
-        } else if (shadowRoot) {
-          const shadowRootObservers = getNodeObservers(shadowRoot);
-
-          if (shadowRootObservers && (shadowRootObservers[0] === observer || ArrayIndexOf.call(shadowRootObservers, observer) !== -1)) {
-            ArrayPush.call(filteredSet, retargetMutationRecord(record));
-          }
+        else {
+            // Mutation happened under a root node(shadow root or document) and the decision is straighforward
+            // Ascend the tree starting from target and check if observer is qualified
+            if (isQualifiedObserver(observer, target)) {
+                ArrayPush.call(filteredSet, record);
+            }
         }
-      }
-    } else {
-      // Mutation happened under a root node(shadow root or document) and the decision is straighforward
-      // Ascend the tree starting from target and check if observer is qualified
-      if (isQualifiedObserver(observer, target)) {
-        ArrayPush.call(filteredSet, record);
-      }
-    }
-
-    return filteredSet;
-  }, []);
+        return filteredSet;
+    }, []);
 }
-
 function getWrappedCallback(callback) {
-  let wrappedCallback = callback[wrapperLookupField];
-
-  if (isUndefined(wrappedCallback)) {
-    wrappedCallback = callback[wrapperLookupField] = (mutations, observer) => {
-      // Filter mutation records
-      const filteredRecords = filterMutationRecords(mutations, observer); // If not records are eligible for the observer, do not invoke callback
-
-      if (filteredRecords.length === 0) {
-        return;
-      }
-
-      callback.call(observer, filteredRecords, observer);
-    };
-  }
-
-  return wrappedCallback;
+    let wrappedCallback = callback[wrapperLookupField];
+    if (isUndefined(wrappedCallback)) {
+        wrappedCallback = callback[wrapperLookupField] = (mutations, observer) => {
+            // Filter mutation records
+            const filteredRecords = filterMutationRecords(mutations, observer);
+            // If not records are eligible for the observer, do not invoke callback
+            if (filteredRecords.length === 0) {
+                return;
+            }
+            callback.call(observer, filteredRecords, observer);
+        };
+    }
+    return wrappedCallback;
 }
 /**
  * Patched MutationObserver constructor.
@@ -3655,33 +3156,27 @@ function getWrappedCallback(callback) {
  * 2. Add a property field to track all observed targets of the observer instance
  * @param {MutationCallback} callback
  */
-
-
 function PatchedMutationObserver(callback) {
-  const wrappedCallback = getWrappedCallback(callback);
-  const observer = new OriginalMutationObserver(wrappedCallback);
-  return observer;
+    const wrappedCallback = getWrappedCallback(callback);
+    const observer = new OriginalMutationObserver(wrappedCallback);
+    return observer;
 }
-
 function patchedDisconnect() {
-  originalDisconnect.call(this); // Clear the node to observer reference which is a strong references
-
-  const observedNodes = observerToNodesMap.get(this);
-
-  if (!isUndefined(observedNodes)) {
-    forEach.call(observedNodes, observedNode => {
-      const observers = observedNode[observerLookupField];
-
-      if (!isUndefined(observers)) {
-        const index = ArrayIndexOf.call(observers, this);
-
-        if (index !== -1) {
-          ArraySplice.call(observers, index, 1);
-        }
-      }
-    });
-    observedNodes.length = 0;
-  }
+    originalDisconnect.call(this);
+    // Clear the node to observer reference which is a strong references
+    const observedNodes = observerToNodesMap.get(this);
+    if (!isUndefined(observedNodes)) {
+        forEach.call(observedNodes, (observedNode) => {
+            const observers = observedNode[observerLookupField];
+            if (!isUndefined(observers)) {
+                const index = ArrayIndexOf.call(observers, this);
+                if (index !== -1) {
+                    ArraySplice.call(observers, index, 1);
+                }
+            }
+        });
+        observedNodes.length = 0;
+    }
 }
 /**
  * A single mutation observer can observe multiple nodes(target).
@@ -3689,57 +3184,47 @@ function patchedDisconnect() {
  * @param {Node} target
  * @param {Object} options
  */
-
-
 function patchedObserve(target, options) {
-  let targetObservers = getNodeObservers(target); // Maintain a list of all observers that want to observe a node
-
-  if (isUndefined(targetObservers)) {
-    targetObservers = [];
-    setNodeObservers(target, targetObservers);
-  } // Same observer trying to observe the same node
-
-
-  if (ArrayIndexOf.call(targetObservers, this) === -1) {
-    ArrayPush.call(targetObservers, this);
-  } // else There is more bookkeeping to do here https://dom.spec.whatwg.org/#dom-mutationobserver-observe Step #7
-  // SyntheticShadowRoot instances are not actually a part of the DOM so observe the host instead.
-
-
-  if (isSyntheticShadowRoot(target)) {
-    target = target.host;
-  } // maintain a list of all nodes observed by this observer
-
-
-  if (observerToNodesMap.has(this)) {
-    const observedNodes = observerToNodesMap.get(this);
-
-    if (ArrayIndexOf.call(observedNodes, target) === -1) {
-      ArrayPush.call(observedNodes, target);
+    let targetObservers = getNodeObservers(target);
+    // Maintain a list of all observers that want to observe a node
+    if (isUndefined(targetObservers)) {
+        targetObservers = [];
+        setNodeObservers(target, targetObservers);
     }
-  } else {
-    observerToNodesMap.set(this, [target]);
-  }
-
-  return originalObserve.call(this, target, options);
+    // Same observer trying to observe the same node
+    if (ArrayIndexOf.call(targetObservers, this) === -1) {
+        ArrayPush.call(targetObservers, this);
+    } // else There is more bookkeeping to do here https://dom.spec.whatwg.org/#dom-mutationobserver-observe Step #7
+    // SyntheticShadowRoot instances are not actually a part of the DOM so observe the host instead.
+    if (isSyntheticShadowRoot(target)) {
+        target = target.host;
+    }
+    // maintain a list of all nodes observed by this observer
+    if (observerToNodesMap.has(this)) {
+        const observedNodes = observerToNodesMap.get(this);
+        if (ArrayIndexOf.call(observedNodes, target) === -1) {
+            ArrayPush.call(observedNodes, target);
+        }
+    }
+    else {
+        observerToNodesMap.set(this, [target]);
+    }
+    return originalObserve.call(this, target, options);
 }
 /**
  * Patch the takeRecords() api to filter MutationRecords based on the observed targets
  */
-
-
 function patchedTakeRecords() {
-  return filterMutationRecords(originalTakeRecords.call(this), this);
+    return filterMutationRecords(originalTakeRecords.call(this), this);
 }
-
 PatchedMutationObserver.prototype = OriginalMutationObserver.prototype;
 PatchedMutationObserver.prototype.disconnect = patchedDisconnect;
 PatchedMutationObserver.prototype.observe = patchedObserve;
 PatchedMutationObserver.prototype.takeRecords = patchedTakeRecords;
 defineProperty(window, 'MutationObserver', {
-  value: PatchedMutationObserver,
-  configurable: true,
-  writable: true
+    value: PatchedMutationObserver,
+    configurable: true,
+    writable: true,
 });
 
 /*
@@ -3748,70 +3233,60 @@ defineProperty(window, 'MutationObserver', {
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
 function patchedAddEventListener$1(type, listener, optionsOrCapture) {
-  if (isSyntheticShadowHost(this)) {
-    // Typescript does not like it when you treat the `arguments` object as an array
-    // @ts-ignore type-mismatch
-    return addCustomElementEventListener.apply(this, arguments);
-  }
-
-  if (arguments.length < 2) {
-    // Slow path, unlikely to be called frequently. We expect modern browsers to throw:
-    // https://googlechrome.github.io/samples/event-listeners-mandatory-arguments/
-    const args = ArraySlice.call(arguments);
-
-    if (args.length > 1) {
-      args[1] = getEventListenerWrapper(args[1]);
-    } // Ignore types because we're passing through to native method
-    // @ts-ignore type-mismatch
-
-
-    return addEventListener.apply(this, args);
-  } // Fast path. This function is optimized to avoid ArraySlice because addEventListener is called
-  // very frequently, and it provides a measurable perf boost to avoid so much array cloning.
-
-
-  const wrappedListener = getEventListenerWrapper(listener); // The third argument is optional, so passing in `undefined` for `optionsOrCapture` gives capture=false
-
-  return addEventListener.call(this, type, wrappedListener, optionsOrCapture);
+    if (isSyntheticShadowHost(this)) {
+        // Typescript does not like it when you treat the `arguments` object as an array
+        // @ts-ignore type-mismatch
+        return addCustomElementEventListener.apply(this, arguments);
+    }
+    if (arguments.length < 2) {
+        // Slow path, unlikely to be called frequently. We expect modern browsers to throw:
+        // https://googlechrome.github.io/samples/event-listeners-mandatory-arguments/
+        const args = ArraySlice.call(arguments);
+        if (args.length > 1) {
+            args[1] = getEventListenerWrapper(args[1]);
+        }
+        // Ignore types because we're passing through to native method
+        // @ts-ignore type-mismatch
+        return addEventListener.apply(this, args);
+    }
+    // Fast path. This function is optimized to avoid ArraySlice because addEventListener is called
+    // very frequently, and it provides a measurable perf boost to avoid so much array cloning.
+    const wrappedListener = getEventListenerWrapper(listener);
+    // The third argument is optional, so passing in `undefined` for `optionsOrCapture` gives capture=false
+    return addEventListener.call(this, type, wrappedListener, optionsOrCapture);
 }
-
 function patchedRemoveEventListener$1(_type, _listener, _optionsOrCapture) {
-  if (isSyntheticShadowHost(this)) {
+    if (isSyntheticShadowHost(this)) {
+        // Typescript does not like it when you treat the `arguments` object as an array
+        // @ts-ignore type-mismatch
+        return removeCustomElementEventListener.apply(this, arguments);
+    }
+    const args = ArraySlice.call(arguments);
+    if (arguments.length > 1) {
+        args[1] = getEventListenerWrapper(args[1]);
+    }
+    // Ignore types because we're passing through to native method
+    // @ts-ignore type-mismatch
+    removeEventListener.apply(this, args);
+    // Account for listeners that were added before this polyfill was applied
     // Typescript does not like it when you treat the `arguments` object as an array
     // @ts-ignore type-mismatch
-    return removeCustomElementEventListener.apply(this, arguments);
-  }
-
-  const args = ArraySlice.call(arguments);
-
-  if (arguments.length > 1) {
-    args[1] = getEventListenerWrapper(args[1]);
-  } // Ignore types because we're passing through to native method
-  // @ts-ignore type-mismatch
-
-
-  removeEventListener.apply(this, args); // Account for listeners that were added before this polyfill was applied
-  // Typescript does not like it when you treat the `arguments` object as an array
-  // @ts-ignore type-mismatch
-
-  removeEventListener.apply(this, arguments);
+    removeEventListener.apply(this, arguments);
 }
-
 defineProperties(eventTargetPrototype, {
-  addEventListener: {
-    value: patchedAddEventListener$1,
-    enumerable: true,
-    writable: true,
-    configurable: true
-  },
-  removeEventListener: {
-    value: patchedRemoveEventListener$1,
-    enumerable: true,
-    writable: true,
-    configurable: true
-  }
+    addEventListener: {
+        value: patchedAddEventListener$1,
+        enumerable: true,
+        writable: true,
+        configurable: true,
+    },
+    removeEventListener: {
+        value: patchedRemoveEventListener$1,
+        enumerable: true,
+        writable: true,
+        configurable: true,
+    },
 });
 
 /*
@@ -3821,7 +3296,7 @@ defineProperties(eventTargetPrototype, {
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 function detect() {
-  return typeof EventTarget === 'undefined';
+    return typeof EventTarget === 'undefined';
 }
 
 /*
@@ -3830,51 +3305,46 @@ function detect() {
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
 function patchedAddEventListener(_type, _listener, _options) {
-  if (arguments.length > 1) {
-    const args = ArraySlice.call(arguments);
-    args[1] = getEventListenerWrapper(args[1]); // Ignore types because we're passing through to native method
+    if (arguments.length > 1) {
+        const args = ArraySlice.call(arguments);
+        args[1] = getEventListenerWrapper(args[1]);
+        // Ignore types because we're passing through to native method
+        // @ts-ignore type-mismatch
+        return windowAddEventListener.apply(this, args);
+    }
+    // Typescript does not like it when you treat the `arguments` object as an array
     // @ts-ignore type-mismatch
-
-    return windowAddEventListener.apply(this, args);
-  } // Typescript does not like it when you treat the `arguments` object as an array
-  // @ts-ignore type-mismatch
-
-
-  return windowAddEventListener.apply(this, arguments);
+    return windowAddEventListener.apply(this, arguments);
 }
-
 function patchedRemoveEventListener(_type, _listener, _options) {
-  if (arguments.length > 1) {
-    const args = ArraySlice.call(arguments);
-    args[1] = getEventListenerWrapper(args[1]); // Ignore types because we're passing through to native method
+    if (arguments.length > 1) {
+        const args = ArraySlice.call(arguments);
+        args[1] = getEventListenerWrapper(args[1]);
+        // Ignore types because we're passing through to native method
+        // @ts-ignore type-mismatch
+        windowRemoveEventListener.apply(this, args);
+    }
+    // Account for listeners that were added before this polyfill was applied
+    // Typescript does not like it when you treat the `arguments` object as an array
     // @ts-ignore type-mismatch
-
-    windowRemoveEventListener.apply(this, args);
-  } // Account for listeners that were added before this polyfill was applied
-  // Typescript does not like it when you treat the `arguments` object as an array
-  // @ts-ignore type-mismatch
-
-
-  windowRemoveEventListener.apply(this, arguments);
+    windowRemoveEventListener.apply(this, arguments);
 }
-
 function apply() {
-  defineProperties(Window.prototype, {
-    addEventListener: {
-      value: patchedAddEventListener,
-      enumerable: true,
-      writable: true,
-      configurable: true
-    },
-    removeEventListener: {
-      value: patchedRemoveEventListener,
-      enumerable: true,
-      writable: true,
-      configurable: true
-    }
-  });
+    defineProperties(Window.prototype, {
+        addEventListener: {
+            value: patchedAddEventListener,
+            enumerable: true,
+            writable: true,
+            configurable: true,
+        },
+        removeEventListener: {
+            value: patchedRemoveEventListener,
+            enumerable: true,
+            writable: true,
+            configurable: true,
+        },
+    });
 }
 
 /*
@@ -3883,9 +3353,8 @@ function apply() {
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
 if (detect()) {
-  apply();
+    apply();
 }
 
 /*
@@ -3894,141 +3363,117 @@ if (detect()) {
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-
 function patchedCurrentTargetGetter() {
-  const currentTarget = eventCurrentTargetGetter.call(this);
-
-  if (isNull(currentTarget)) {
-    return null;
-  }
-
-  if (eventToContextMap.get(this) === 1
-  /* SHADOW_ROOT_LISTENER */
-  ) {
-    return getShadowRoot(currentTarget);
-  }
-
-  return currentTarget;
+    const currentTarget = eventCurrentTargetGetter.call(this);
+    if (isNull(currentTarget)) {
+        return null;
+    }
+    if (eventToContextMap.get(this) === 1 /* EventListenerContext.SHADOW_ROOT_LISTENER */) {
+        return getShadowRoot(currentTarget);
+    }
+    return currentTarget;
 }
-
 function patchedTargetGetter() {
-  const originalTarget = eventTargetGetter.call(this);
-
-  if (!(originalTarget instanceof _Node)) {
-    return originalTarget;
-  }
-
-  const doc = getOwnerDocument(originalTarget);
-  const composedPath = pathComposer(originalTarget, this.composed);
-  const originalCurrentTarget = eventCurrentTargetGetter.call(this); // Handle cases where the currentTarget is null (for async events), and when an event has been
-  // added to Window
-
-  if (!(originalCurrentTarget instanceof _Node)) {
-    // TODO [#1511]: Special escape hatch to support legacy behavior. Should be fixed.
-    // If the event's target is being accessed async and originalTarget is not a keyed element, do not retarget
-    if (isNull(originalCurrentTarget) && isUndefined(getNodeOwnerKey(originalTarget))) {
-      return originalTarget;
+    const originalTarget = eventTargetGetter.call(this);
+    if (!(originalTarget instanceof _Node)) {
+        return originalTarget;
     }
-
-    return retarget(doc, composedPath);
-  } else if (originalCurrentTarget === doc || originalCurrentTarget === doc.body) {
-    // TODO [#1530]: If currentTarget is document or document.body (Third party libraries that have global event listeners)
-    // and the originalTarget is not a keyed element, do not retarget
-    if (isUndefined(getNodeOwnerKey(originalTarget))) {
-      return originalTarget;
+    const doc = getOwnerDocument(originalTarget);
+    const composedPath = pathComposer(originalTarget, this.composed);
+    const originalCurrentTarget = eventCurrentTargetGetter.call(this);
+    // Handle cases where the currentTarget is null (for async events), and when an event has been
+    // added to Window
+    if (!(originalCurrentTarget instanceof _Node)) {
+        // TODO [#1511]: Special escape hatch to support legacy behavior. Should be fixed.
+        // If the event's target is being accessed async and originalTarget is not a keyed element, do not retarget
+        if (isNull(originalCurrentTarget) && isUndefined(getNodeOwnerKey(originalTarget))) {
+            return originalTarget;
+        }
+        return retarget(doc, composedPath);
     }
-
-    return retarget(doc, composedPath);
-  }
-
-  let actualCurrentTarget = originalCurrentTarget;
-  let actualPath = composedPath; // Address the possibility that `currentTarget` is a shadow root
-
-  if (isSyntheticShadowHost(originalCurrentTarget)) {
-    const context = eventToContextMap.get(this);
-
-    if (context === 1
-    /* SHADOW_ROOT_LISTENER */
-    ) {
-      actualCurrentTarget = getShadowRoot(originalCurrentTarget);
+    else if (originalCurrentTarget === doc || originalCurrentTarget === doc.body) {
+        // TODO [#1530]: If currentTarget is document or document.body (Third party libraries that have global event listeners)
+        // and the originalTarget is not a keyed element, do not retarget
+        if (isUndefined(getNodeOwnerKey(originalTarget))) {
+            return originalTarget;
+        }
+        return retarget(doc, composedPath);
     }
-  } // Address the possibility that `target` is a shadow root
-
-
-  if (isSyntheticShadowHost(originalTarget) && eventToShadowRootMap.has(this)) {
-    actualPath = pathComposer(getShadowRoot(originalTarget), this.composed);
-  }
-
-  return retarget(actualCurrentTarget, actualPath);
+    let actualCurrentTarget = originalCurrentTarget;
+    let actualPath = composedPath;
+    // Address the possibility that `currentTarget` is a shadow root
+    if (isSyntheticShadowHost(originalCurrentTarget)) {
+        const context = eventToContextMap.get(this);
+        if (context === 1 /* EventListenerContext.SHADOW_ROOT_LISTENER */) {
+            actualCurrentTarget = getShadowRoot(originalCurrentTarget);
+        }
+    }
+    // Address the possibility that `target` is a shadow root
+    if (isSyntheticShadowHost(originalTarget) && eventToShadowRootMap.has(this)) {
+        actualPath = pathComposer(getShadowRoot(originalTarget), this.composed);
+    }
+    return retarget(actualCurrentTarget, actualPath);
 }
-
 function patchedComposedPathValue() {
-  const originalTarget = eventTargetGetter.call(this); // Account for events with targets that are not instances of Node (e.g., when a readystatechange
-  // handler is listening on an instance of XMLHttpRequest).
-
-  if (!(originalTarget instanceof _Node)) {
-    return [];
-  } // If the original target is inside a native shadow root, then just call the native
-  // composePath() method. The event is already retargeted and this causes our composedPath()
-  // polyfill to compute the wrong value. This is only an issue when you have a native web
-  // component inside an LWC component (see test in same commit) but this scenario is unlikely
-  // because we don't yet support that. Workaround specifically for W-9846457. Mixed mode solution
-  // will likely be more involved.
-
-
-  const hasShadowRoot = Boolean(originalTarget.shadowRoot);
-  const hasSyntheticShadowRootAttached = hasInternalSlot(originalTarget);
-
-  if (hasShadowRoot && !hasSyntheticShadowRootAttached) {
-    return composedPath.call(this);
-  }
-
-  const originalCurrentTarget = eventCurrentTargetGetter.call(this); // If the event has completed propagation, the composedPath should be an empty array.
-
-  if (isNull(originalCurrentTarget)) {
-    return [];
-  } // Address the possibility that `target` is a shadow root
-
-
-  let actualTarget = originalTarget;
-
-  if (isSyntheticShadowHost(originalTarget) && eventToShadowRootMap.has(this)) {
-    actualTarget = getShadowRoot(originalTarget);
-  }
-
-  return pathComposer(actualTarget, this.composed);
+    const originalTarget = eventTargetGetter.call(this);
+    // Account for events with targets that are not instances of Node (e.g., when a readystatechange
+    // handler is listening on an instance of XMLHttpRequest).
+    if (!(originalTarget instanceof _Node)) {
+        return [];
+    }
+    // If the original target is inside a native shadow root, then just call the native
+    // composePath() method. The event is already retargeted and this causes our composedPath()
+    // polyfill to compute the wrong value. This is only an issue when you have a native web
+    // component inside an LWC component (see test in same commit) but this scenario is unlikely
+    // because we don't yet support that. Workaround specifically for W-9846457. Mixed mode solution
+    // will likely be more involved.
+    const hasShadowRoot = Boolean(originalTarget.shadowRoot);
+    const hasSyntheticShadowRootAttached = hasInternalSlot(originalTarget);
+    if (hasShadowRoot && !hasSyntheticShadowRootAttached) {
+        return composedPath.call(this);
+    }
+    const originalCurrentTarget = eventCurrentTargetGetter.call(this);
+    // If the event has completed propagation, the composedPath should be an empty array.
+    if (isNull(originalCurrentTarget)) {
+        return [];
+    }
+    // Address the possibility that `target` is a shadow root
+    let actualTarget = originalTarget;
+    if (isSyntheticShadowHost(originalTarget) && eventToShadowRootMap.has(this)) {
+        actualTarget = getShadowRoot(originalTarget);
+    }
+    return pathComposer(actualTarget, this.composed);
 }
-
 defineProperties(Event.prototype, {
-  target: {
-    get: patchedTargetGetter,
-    enumerable: true,
-    configurable: true
-  },
-  currentTarget: {
-    get: patchedCurrentTargetGetter,
-    enumerable: true,
-    configurable: true
-  },
-  composedPath: {
-    value: patchedComposedPathValue,
-    writable: true,
-    enumerable: true,
-    configurable: true
-  },
-  // Non-standard but widely supported for backwards-compatibility
-  srcElement: {
-    get: patchedTargetGetter,
-    enumerable: true,
-    configurable: true
-  },
-  // Non-standard but implemented in Chrome and continues to exist for backwards-compatibility
-  // https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/dom/events/event.idl;l=58?q=event.idl&ss=chromium
-  path: {
-    get: patchedComposedPathValue,
-    enumerable: true,
-    configurable: true
-  }
+    target: {
+        get: patchedTargetGetter,
+        enumerable: true,
+        configurable: true,
+    },
+    currentTarget: {
+        get: patchedCurrentTargetGetter,
+        enumerable: true,
+        configurable: true,
+    },
+    composedPath: {
+        value: patchedComposedPathValue,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+    },
+    // Non-standard but widely supported for backwards-compatibility
+    srcElement: {
+        get: patchedTargetGetter,
+        enumerable: true,
+        configurable: true,
+    },
+    // Non-standard but implemented in Chrome and continues to exist for backwards-compatibility
+    // https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/core/dom/events/event.idl;l=58?q=event.idl&ss=chromium
+    path: {
+        get: patchedComposedPathValue,
+        enumerable: true,
+        configurable: true,
+    },
 });
 
 /*
@@ -4038,31 +3483,26 @@ defineProperties(Event.prototype, {
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 function retargetRelatedTarget(Ctor) {
-  const relatedTargetGetter = getOwnPropertyDescriptor(Ctor.prototype, 'relatedTarget').get;
-  defineProperty(Ctor.prototype, 'relatedTarget', {
-    get() {
-      const relatedTarget = relatedTargetGetter.call(this);
-
-      if (isNull(relatedTarget)) {
-        return null;
-      }
-
-      if (!(relatedTarget instanceof _Node) || !isNodeShadowed(relatedTarget)) {
-        return relatedTarget;
-      }
-
-      let pointOfReference = eventCurrentTargetGetter.call(this);
-
-      if (isNull(pointOfReference)) {
-        pointOfReference = getOwnerDocument(relatedTarget);
-      }
-
-      return retarget(pointOfReference, pathComposer(relatedTarget, true));
-    },
-
-    enumerable: true,
-    configurable: true
-  });
+    const relatedTargetGetter = getOwnPropertyDescriptor(Ctor.prototype, 'relatedTarget')
+        .get;
+    defineProperty(Ctor.prototype, 'relatedTarget', {
+        get() {
+            const relatedTarget = relatedTargetGetter.call(this);
+            if (isNull(relatedTarget)) {
+                return null;
+            }
+            if (!(relatedTarget instanceof _Node) || !isNodeShadowed(relatedTarget)) {
+                return relatedTarget;
+            }
+            let pointOfReference = eventCurrentTargetGetter.call(this);
+            if (isNull(pointOfReference)) {
+                pointOfReference = getOwnerDocument(relatedTarget);
+            }
+            return retarget(pointOfReference, pathComposer(relatedTarget, true));
+        },
+        enumerable: true,
+        configurable: true,
+    });
 }
 
 /*
@@ -4082,153 +3522,162 @@ retargetRelatedTarget(FocusEvent);
 retargetRelatedTarget(MouseEvent);
 
 /*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+const assignedSlotGetter = hasOwnProperty.call(Text.prototype, 'assignedSlot')
+    ? getOwnPropertyDescriptor(Text.prototype, 'assignedSlot').get
+    : () => null;
+
+/*
  * Copyright (c) 2018, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+// We can use a single observer without having to worry about leaking because
 // "Registered observers in a node’s registered observer list have a weak
 // reference to the node."
 // https://dom.spec.whatwg.org/#garbage-collection
-
 let observer;
-const observerConfig = {
-  childList: true
-};
+const observerConfig = { childList: true };
 const SlotChangeKey = new WeakMap();
-
 function initSlotObserver() {
-  return new MO(mutations => {
-    const slots = [];
-    forEach.call(mutations, mutation => {
-      if (true) {
-        assert.invariant(mutation.type === 'childList', `Invalid mutation type: ${mutation.type}. This mutation handler for slots should only handle "childList" mutations.`);
-      }
-
-      const {
-        target: slot
-      } = mutation;
-
-      if (ArrayIndexOf.call(slots, slot) === -1) {
-        ArrayPush.call(slots, slot);
-        dispatchEvent.call(slot, new CustomEvent('slotchange'));
-      }
+    return new MO((mutations) => {
+        const slots = [];
+        forEach.call(mutations, (mutation) => {
+            if (true) {
+                assert.invariant(mutation.type === 'childList', `Invalid mutation type: ${mutation.type}. This mutation handler for slots should only handle "childList" mutations.`);
+            }
+            const { target: slot } = mutation;
+            if (ArrayIndexOf.call(slots, slot) === -1) {
+                ArrayPush.call(slots, slot);
+                dispatchEvent.call(slot, new CustomEvent('slotchange'));
+            }
+        });
     });
-  });
 }
-
 function getFilteredSlotFlattenNodes(slot) {
-  const childNodes = arrayFromCollection(childNodesGetter.call(slot)); // Typescript is inferring the wrong function type for this particular
-  // overloaded method: https://github.com/Microsoft/TypeScript/issues/27972
-  // @ts-ignore type-mismatch
-
-  return ArrayReduce.call(childNodes, (seed, child) => {
-    if (child instanceof Element && isSlotElement(child)) {
-      ArrayPush.apply(seed, getFilteredSlotFlattenNodes(child));
-    } else {
-      ArrayPush.call(seed, child);
-    }
-
-    return seed;
-  }, []);
+    const childNodes = arrayFromCollection(childNodesGetter.call(slot));
+    // Typescript is inferring the wrong function type for this particular
+    // overloaded method: https://github.com/Microsoft/TypeScript/issues/27972
+    // @ts-ignore type-mismatch
+    return ArrayReduce.call(childNodes, (seed, child) => {
+        if (child instanceof Element && isSlotElement(child)) {
+            ArrayPush.apply(seed, getFilteredSlotFlattenNodes(child));
+        }
+        else {
+            ArrayPush.call(seed, child);
+        }
+        return seed;
+    }, []);
 }
-
 function assignedSlotGetterPatched() {
-  const parentNode = parentNodeGetter.call(this);
-  /**
-   * The node is assigned to a slot if:
-   *  - it has a parent and it parent its parent is a slot element
-   *  - and if the slot owner key is different than the node owner key.
-   *
-   * When the slot and the slotted node are 2 different shadow trees, the owner keys will be
-   * different. When the slot is in a shadow tree and the slotted content is a light DOM node,
-   * the light DOM node doesn't have an owner key and therefor the slot owner key will be
-   * different than the node owner key (always `undefined`).
-   */
-
-  if (!isNull(parentNode) && isSlotElement(parentNode) && getNodeOwnerKey(parentNode) !== getNodeOwnerKey(this)) {
-    return parentNode;
-  }
-
-  return null;
+    const parentNode = parentNodeGetter.call(this);
+    // use original assignedSlot if parent has a native shdow root
+    if (parentNode instanceof Element) {
+        const sr = shadowRootGetter.call(parentNode);
+        if (isInstanceOfNativeShadowRoot(sr)) {
+            if (this instanceof Text) {
+                return assignedSlotGetter.call(this);
+            }
+            return assignedSlotGetter$1.call(this);
+        }
+    }
+    /**
+     * The node is assigned to a slot if:
+     *  - it has a parent and its parent is a slot element
+     *  - and if the slot owner key is different than the node owner key.
+     *
+     * When the slot and the slotted node are 2 different shadow trees, the owner keys will be
+     * different. When the slot is in a shadow tree and the slotted content is a light DOM node,
+     * the light DOM node doesn't have an owner key and therefor the slot owner key will be
+     * different than the node owner key (always `undefined`).
+     */
+    if (!isNull(parentNode) &&
+        isSlotElement(parentNode) &&
+        getNodeOwnerKey(parentNode) !== getNodeOwnerKey(this)) {
+        return parentNode;
+    }
+    return null;
 }
 defineProperties(HTMLSlotElement.prototype, {
-  addEventListener: {
-    value(type, listener, options) {
-      // super.addEventListener - but that doesn't work with typescript
-      HTMLElement.prototype.addEventListener.call(this, type, listener, options);
-
-      if (type === 'slotchange' && !SlotChangeKey.get(this)) {
-        SlotChangeKey.set(this, true);
-
-        if (!observer) {
-          observer = initSlotObserver();
-        }
-
-        MutationObserverObserve.call(observer, this, observerConfig);
-      }
+    addEventListener: {
+        value(type, listener, options) {
+            // super.addEventListener - but that doesn't work with typescript
+            HTMLElement.prototype.addEventListener.call(this, type, listener, options);
+            if (type === 'slotchange' && !SlotChangeKey.get(this)) {
+                SlotChangeKey.set(this, true);
+                if (!observer) {
+                    observer = initSlotObserver();
+                }
+                MutationObserverObserve.call(observer, this, observerConfig);
+            }
+        },
+        writable: true,
+        enumerable: true,
+        configurable: true,
     },
-
-    writable: true,
-    enumerable: true,
-    configurable: true
-  },
-  assignedElements: {
-    value(options) {
-      if (isNodeShadowed(this)) {
-        const flatten = !isUndefined(options) && isTrue(options.flatten);
-        const nodes = flatten ? getFilteredSlotFlattenNodes(this) : getFilteredSlotAssignedNodes(this);
-        return ArrayFilter.call(nodes, node => node instanceof Element);
-      } else {
-        return assignedElements.apply(this, ArraySlice.call(arguments));
-      }
+    assignedElements: {
+        value(options) {
+            if (isNodeShadowed(this)) {
+                const flatten = !isUndefined(options) && isTrue(options.flatten);
+                const nodes = flatten
+                    ? getFilteredSlotFlattenNodes(this)
+                    : getFilteredSlotAssignedNodes(this);
+                return ArrayFilter.call(nodes, (node) => node instanceof Element);
+            }
+            else {
+                return assignedElements.apply(this, ArraySlice.call(arguments));
+            }
+        },
+        writable: true,
+        enumerable: true,
+        configurable: true,
     },
-
-    writable: true,
-    enumerable: true,
-    configurable: true
-  },
-  assignedNodes: {
-    value(options) {
-      if (isNodeShadowed(this)) {
-        const flatten = !isUndefined(options) && isTrue(options.flatten);
-        return flatten ? getFilteredSlotFlattenNodes(this) : getFilteredSlotAssignedNodes(this);
-      } else {
-        return assignedNodes.apply(this, ArraySlice.call(arguments));
-      }
+    assignedNodes: {
+        value(options) {
+            if (isNodeShadowed(this)) {
+                const flatten = !isUndefined(options) && isTrue(options.flatten);
+                return flatten
+                    ? getFilteredSlotFlattenNodes(this)
+                    : getFilteredSlotAssignedNodes(this);
+            }
+            else {
+                return assignedNodes.apply(this, ArraySlice.call(arguments));
+            }
+        },
+        writable: true,
+        enumerable: true,
+        configurable: true,
     },
-
-    writable: true,
-    enumerable: true,
-    configurable: true
-  },
-  name: {
-    get() {
-      const name = getAttribute.call(this, 'name');
-      return isNull(name) ? '' : name;
+    name: {
+        get() {
+            const name = getAttribute.call(this, 'name');
+            return isNull(name) ? '' : name;
+        },
+        set(value) {
+            setAttribute.call(this, 'name', value);
+        },
+        enumerable: true,
+        configurable: true,
     },
-
-    set(value) {
-      setAttribute.call(this, 'name', value);
+    childNodes: {
+        get() {
+            if (isNodeShadowed(this)) {
+                const owner = getNodeOwner(this);
+                const childNodes = isNull(owner)
+                    ? []
+                    : getAllMatches(owner, getFilteredChildNodes(this));
+                return createStaticNodeList(childNodes);
+            }
+            return childNodesGetter.call(this);
+        },
+        enumerable: true,
+        configurable: true,
     },
-
-    enumerable: true,
-    configurable: true
-  },
-  childNodes: {
-    get() {
-      if (isNodeShadowed(this)) {
-        const owner = getNodeOwner(this);
-        const childNodes = isNull(owner) ? [] : getAllMatches(owner, getFilteredChildNodes(this));
-        return createStaticNodeList(childNodes);
-      }
-
-      return childNodesGetter.call(this);
-    },
-
-    enumerable: true,
-    configurable: true
-  }
 });
 
 /*
@@ -4237,14 +3686,14 @@ defineProperties(HTMLSlotElement.prototype, {
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+// Non-deep-traversing patches: this descriptor map includes all descriptors that
 // do not five access to nodes beyond the immediate children.
-
 defineProperties(Text.prototype, {
-  assignedSlot: {
-    get: assignedSlotGetterPatched,
-    enumerable: true,
-    configurable: true
-  }
+    assignedSlot: {
+        get: assignedSlotGetterPatched,
+        enumerable: true,
+        configurable: true,
+    },
 });
 
 /*
@@ -4257,39 +3706,42 @@ defineProperties(Text.prototype, {
  * This methods filters out elements that are not in the same shadow root of context.
  * It does not enforce shadow dom semantics if $context is not managed by LWC
  */
-
 function getNonPatchedFilteredArrayOfNodes(context, unfilteredNodes) {
-  let filtered;
-  const ownerKey = getNodeOwnerKey(context); // a node inside a shadow.
-
-  if (!isUndefined(ownerKey)) {
-    if (isSyntheticShadowHost(context)) {
-      // element with shadowRoot attached
-      const owner = getNodeOwner(context);
-
-      if (isNull(owner)) {
-        filtered = [];
-      } else if (getNodeKey(context)) {
-        // it is a custom element, and we should then filter by slotted elements
-        filtered = getAllSlottedMatches(context, unfilteredNodes);
-      } else {
-        // regular element, we should then filter by ownership
-        filtered = getAllMatches(owner, unfilteredNodes);
-      }
-    } else {
-      // context is handled by lwc, using getNodeNearestOwnerKey to include manually inserted elements in the same shadow.
-      filtered = ArrayFilter.call(unfilteredNodes, elm => getNodeNearestOwnerKey(elm) === ownerKey);
+    let filtered;
+    const ownerKey = getNodeOwnerKey(context);
+    // a node inside a shadow.
+    if (!isUndefined(ownerKey)) {
+        if (isSyntheticShadowHost(context)) {
+            // element with shadowRoot attached
+            const owner = getNodeOwner(context);
+            if (isNull(owner)) {
+                filtered = [];
+            }
+            else if (getNodeKey(context)) {
+                // it is a custom element, and we should then filter by slotted elements
+                filtered = getAllSlottedMatches(context, unfilteredNodes);
+            }
+            else {
+                // regular element, we should then filter by ownership
+                filtered = getAllMatches(owner, unfilteredNodes);
+            }
+        }
+        else {
+            // context is handled by lwc, using getNodeNearestOwnerKey to include manually inserted elements in the same shadow.
+            filtered = ArrayFilter.call(unfilteredNodes, (elm) => getNodeNearestOwnerKey(elm) === ownerKey);
+        }
     }
-  } else if (context instanceof HTMLBodyElement) {
-    // `context` is document.body which is already patched.
-    filtered = ArrayFilter.call(unfilteredNodes, // TODO [#1222]: remove global bypass
-    elm => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(context));
-  } else {
-    // `context` is outside the lwc boundary, return unfiltered list.
-    filtered = ArraySlice.call(unfilteredNodes);
-  }
-
-  return filtered;
+    else if (context instanceof HTMLBodyElement) {
+        // `context` is document.body which is already patched.
+        filtered = ArrayFilter.call(unfilteredNodes, 
+        // TODO [#1222]: remove global bypass
+        (elm) => isUndefined(getNodeOwnerKey(elm)) || isGlobalPatchingSkipped(context));
+    }
+    else {
+        // `context` is outside the lwc boundary, return unfiltered list.
+        filtered = ArraySlice.call(unfilteredNodes);
+    }
+    return filtered;
 }
 
 /*
@@ -4361,7 +3813,7 @@ function lastElementChildGetterPatched() {
 defineProperties(Element.prototype, {
   innerHTML: {
     get() {
-      if (!runtimeFlags.ENABLE_ELEMENT_PATCH) {
+      if (!lwcRuntimeFlags.ENABLE_ELEMENT_PATCH) {
         if (isNodeShadowed(this) || isSyntheticShadowHost(this)) {
           return innerHTMLGetterPatched.call(this);
         }
@@ -4386,7 +3838,7 @@ defineProperties(Element.prototype, {
   },
   outerHTML: {
     get() {
-      if (!runtimeFlags.ENABLE_ELEMENT_PATCH) {
+      if (!lwcRuntimeFlags.ENABLE_ELEMENT_PATCH) {
         if (isNodeShadowed(this) || isSyntheticShadowHost(this)) {
           return outerHTMLGetterPatched.call(this);
         }
@@ -4514,7 +3966,7 @@ function querySelectorPatched() {
       const elm = ArrayFind.call(nodeList, elm => getNodeNearestOwnerKey(elm) === ownerKey);
       return isUndefined(elm) ? null : elm;
     } else {
-      if (!runtimeFlags.ENABLE_NODE_LIST_PATCH) {
+      if (!lwcRuntimeFlags.ENABLE_NODE_LIST_PATCH) {
         // `this` is a manually inserted element inside a shadowRoot, return the first element.
         return nodeList.length === 0 ? null : nodeList[0];
       } // Element is inside a shadow but we dont know which one. Use the
@@ -4526,7 +3978,7 @@ function querySelectorPatched() {
       return isUndefined(elm) ? null : elm;
     }
   } else {
-    if (!runtimeFlags.ENABLE_NODE_LIST_PATCH) {
+    if (!lwcRuntimeFlags.ENABLE_NODE_LIST_PATCH) {
       if (!(this instanceof HTMLBodyElement)) {
         const elm = nodeList[0];
         return isUndefined(elm) ? null : elm;
@@ -4564,7 +4016,7 @@ function getFilteredArrayOfNodes(context, unfilteredNodes, shadowDomSemantic) {
       // context is handled by lwc, using getNodeNearestOwnerKey to include manually inserted elements in the same shadow.
       filtered = ArrayFilter.call(unfilteredNodes, elm => getNodeNearestOwnerKey(elm) === ownerKey);
     } else if (shadowDomSemantic === 1
-    /* Enabled */
+    /* ShadowDomSemantic.Enabled */
     ) {
       // context is inside a shadow, we dont know which one.
       const contextNearestOwnerKey = getNodeNearestOwnerKey(context);
@@ -4575,7 +4027,7 @@ function getFilteredArrayOfNodes(context, unfilteredNodes, shadowDomSemantic) {
     }
   } else {
     if (context instanceof HTMLBodyElement || shadowDomSemantic === 1
-    /* Enabled */
+    /* ShadowDomSemantic.Enabled */
     ) {
       // `context` is document.body or element belonging to the document with the patch enabled
       filtered = ArrayFilter.call(unfilteredNodes, // TODO [#1222]: remove global bypass
@@ -4609,15 +4061,15 @@ defineProperties(Element.prototype, {
     value() {
       const nodeList = arrayFromCollection(querySelectorAll$1.apply(this, ArraySlice.call(arguments)));
 
-      if (!runtimeFlags.ENABLE_NODE_LIST_PATCH) {
+      if (!lwcRuntimeFlags.ENABLE_NODE_LIST_PATCH) {
         const filteredResults = getFilteredArrayOfNodes(this, nodeList, 0
-        /* Disabled */
+        /* ShadowDomSemantic.Disabled */
         );
         return createStaticNodeList(filteredResults);
       }
 
       return createStaticNodeList(getFilteredArrayOfNodes(this, nodeList, 1
-      /* Enabled */
+      /* ShadowDomSemantic.Enabled */
       ));
     },
 
@@ -4633,12 +4085,12 @@ if (true) {
       value() {
         const elements = arrayFromCollection(getElementsByClassName$1.apply(this, ArraySlice.call(arguments)));
 
-        if (!runtimeFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
+        if (!lwcRuntimeFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
           return createStaticHTMLCollection(getNonPatchedFilteredArrayOfNodes(this, elements));
         }
 
         const filteredResults = getFilteredArrayOfNodes(this, elements, 1
-        /* Enabled */
+        /* ShadowDomSemantic.Enabled */
         );
         return createStaticHTMLCollection(filteredResults);
       },
@@ -4651,12 +4103,12 @@ if (true) {
       value() {
         const elements = arrayFromCollection(getElementsByTagName$1.apply(this, ArraySlice.call(arguments)));
 
-        if (!runtimeFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
+        if (!lwcRuntimeFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
           return createStaticHTMLCollection(getNonPatchedFilteredArrayOfNodes(this, elements));
         }
 
         const filteredResults = getFilteredArrayOfNodes(this, elements, 1
-        /* Enabled */
+        /* ShadowDomSemantic.Enabled */
         );
         return createStaticHTMLCollection(filteredResults);
       },
@@ -4669,12 +4121,12 @@ if (true) {
       value() {
         const elements = arrayFromCollection(getElementsByTagNameNS$1.apply(this, ArraySlice.call(arguments)));
 
-        if (!runtimeFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
+        if (!lwcRuntimeFlags.ENABLE_HTML_COLLECTIONS_PATCH) {
           return createStaticHTMLCollection(getNonPatchedFilteredArrayOfNodes(this, elements));
         }
 
         const filteredResults = getFilteredArrayOfNodes(this, elements, 1
-        /* Enabled */
+        /* ShadowDomSemantic.Enabled */
         );
         return createStaticHTMLCollection(filteredResults);
       },
@@ -4697,6 +4149,195 @@ if (hasOwnProperty.call(HTMLElement.prototype, 'getElementsByClassName')) {
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
+function getElementComputedStyle(element) {
+    const win = getOwnerWindow(element);
+    return windowGetComputedStyle.call(win, element);
+}
+function getWindowSelection(node) {
+    const win = getOwnerWindow(node);
+    return windowGetSelection.call(win);
+}
+function nodeIsBeingRendered(nodeComputedStyle) {
+    return nodeComputedStyle.visibility === 'visible' && nodeComputedStyle.display !== 'none';
+}
+function getSelectionState(element) {
+    const win = getOwnerWindow(element);
+    const selection = getWindowSelection(element);
+    if (selection === null) {
+        return null;
+    }
+    const ranges = [];
+    for (let i = 0; i < selection.rangeCount; i++) {
+        ranges.push(selection.getRangeAt(i));
+    }
+    const state = {
+        element,
+        onselect: win.onselect,
+        onselectstart: win.onselectstart,
+        onselectionchange: win.onselectionchange,
+        ranges,
+    };
+    win.onselect = null;
+    win.onselectstart = null;
+    win.onselectionchange = null;
+    return state;
+}
+function restoreSelectionState(state) {
+    if (state === null) {
+        return;
+    }
+    const { element, onselect, onselectstart, onselectionchange, ranges } = state;
+    const win = getOwnerWindow(element);
+    const selection = getWindowSelection(element);
+    selection.removeAllRanges();
+    for (let i = 0; i < ranges.length; i++) {
+        selection.addRange(ranges[i]);
+    }
+    win.onselect = onselect;
+    win.onselectstart = onselectstart;
+    win.onselectionchange = onselectionchange;
+}
+/**
+ * Gets the "innerText" of a text node using the Selection API
+ *
+ * NOTE: For performance reasons, since this function will be called multiple times while calculating the innerText of
+ *       an element, it does not restore the current selection.
+ */
+function getTextNodeInnerText(textNode) {
+    const selection = getWindowSelection(textNode);
+    if (selection === null) {
+        return textNode.textContent || '';
+    }
+    const range = document.createRange();
+    range.selectNodeContents(textNode);
+    const domRect = range.getBoundingClientRect();
+    if (domRect.height <= 0 || domRect.width <= 0) {
+        // the text node is not rendered
+        return '';
+    }
+    // Needed to remove non rendered characters from the text node.
+    selection.removeAllRanges();
+    selection.addRange(range);
+    const selectionText = selection.toString();
+    // The textNode is visible, but it may not be selectable. When the text is not selectable,
+    // textContent is the nearest approximation to innerText.
+    return selectionText ? selectionText : textNode.textContent || '';
+}
+const nodeIsElement = (node) => node.nodeType === ELEMENT_NODE;
+const nodeIsText = (node) => node.nodeType === TEXT_NODE;
+/**
+ * Spec: https://html.spec.whatwg.org/multipage/dom.html#inner-text-collection-steps
+ * One spec implementation: https://github.com/servo/servo/blob/721271dcd3c20db5ca8cf146e2b5907647afb4d6/components/layout/query.rs#L1132
+ */
+function innerTextCollectionSteps(node) {
+    const items = [];
+    if (nodeIsElement(node)) {
+        const { tagName } = node;
+        const computedStyle = getElementComputedStyle(node);
+        if (tagName === 'OPTION') {
+            // For options, is hard to get the "rendered" text, let's use the original getter.
+            return [1, innerTextGetter.call(node), 1];
+        }
+        else if (tagName === 'TEXTAREA') {
+            return [];
+        }
+        else {
+            const childNodes = node.childNodes;
+            for (let i = 0, n = childNodes.length; i < n; i++) {
+                ArrayPush.apply(items, innerTextCollectionSteps(childNodes[i]));
+            }
+        }
+        if (!nodeIsBeingRendered(computedStyle)) {
+            if (tagName === 'SELECT' || tagName === 'DATALIST') {
+                // the select is either: .visibility != 'visible' or .display === hidden, therefore this select should
+                // not display any value.
+                return [];
+            }
+            return items;
+        }
+        if (tagName === 'BR') {
+            items.push('\u{000A}' /* line feed */);
+        }
+        const { display } = computedStyle;
+        if (display === 'table-cell') {
+            // omitting case: and node's CSS box is not the last 'table-cell' box of its enclosing 'table-row' box
+            items.push('\u{0009}' /* tab */);
+        }
+        if (display === 'table-row') {
+            // omitting case: and node's CSS box is not the last 'table-row' box of the nearest ancestor 'table' box
+            items.push('\u{000A}' /* line feed */);
+        }
+        if (tagName === 'P') {
+            items.unshift(2);
+            items.push(2);
+        }
+        if (display === 'block' ||
+            display === 'table-caption' ||
+            display === 'flex' ||
+            display === 'table') {
+            items.unshift(1);
+            items.push(1);
+        }
+    }
+    else if (nodeIsText(node)) {
+        items.push(getTextNodeInnerText(node));
+    }
+    return items;
+}
+/**
+ * InnerText getter spec: https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute
+ *
+ * One spec implementation: https://github.com/servo/servo/blob/721271dcd3c20db5ca8cf146e2b5907647afb4d6/components/layout/query.rs#L1087
+ */
+function getInnerText(element) {
+    const thisComputedStyle = getElementComputedStyle(element);
+    if (!nodeIsBeingRendered(thisComputedStyle)) {
+        return getTextContent(element) || '';
+    }
+    const selectionState = getSelectionState(element);
+    const results = [];
+    const childNodes = element.childNodes;
+    for (let i = 0, n = childNodes.length; i < n; i++) {
+        ArrayPush.apply(results, innerTextCollectionSteps(childNodes[i]));
+    }
+    restoreSelectionState(selectionState);
+    let elementInnerText = '';
+    let maxReqLineBreakCount = 0;
+    for (let i = 0, n = results.length; i < n; i++) {
+        const item = results[i];
+        if (typeof item === 'string') {
+            if (maxReqLineBreakCount > 0) {
+                for (let j = 0; j < maxReqLineBreakCount; j++) {
+                    elementInnerText += '\u{000A}';
+                }
+                maxReqLineBreakCount = 0;
+            }
+            if (item.length > 0) {
+                elementInnerText += item;
+            }
+        }
+        else {
+            if (elementInnerText.length == 0) {
+                // Remove required line break count at the start.
+                continue;
+            }
+            // Store the count if it's the max of this run,
+            // but it may be ignored if no text item is found afterwards,
+            // which means that these are consecutive line breaks at the end.
+            if (item > maxReqLineBreakCount) {
+                maxReqLineBreakCount = item;
+            }
+        }
+    }
+    return elementInnerText;
+}
+
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
 const FocusableSelector = `
     [contenteditable],
     [tabindex],
@@ -4711,623 +4352,325 @@ const FocusableSelector = `
     video[controls]
 `;
 const formElementTagNames = new Set(['BUTTON', 'INPUT', 'SELECT', 'TEXTAREA']);
-
 function filterSequentiallyFocusableElements(elements) {
-  return elements.filter(element => {
-    if (hasAttribute.call(element, 'tabindex')) {
-      // Even though LWC only supports tabindex values of 0 or -1,
-      // passing through elements with tabindex="0" is a tighter criteria
-      // than filtering out elements based on tabindex="-1".
-      return getAttribute.call(element, 'tabindex') === '0';
-    }
-
-    if (formElementTagNames.has(tagNameGetter.call(element))) {
-      return !hasAttribute.call(element, 'disabled');
-    }
-
-    return true;
-  });
+    return elements.filter((element) => {
+        if (hasAttribute.call(element, 'tabindex')) {
+            // Even though LWC only supports tabindex values of 0 or -1,
+            // passing through elements with tabindex="0" is a tighter criteria
+            // than filtering out elements based on tabindex="-1".
+            return getAttribute.call(element, 'tabindex') === '0';
+        }
+        if (formElementTagNames.has(tagNameGetter.call(element))) {
+            return !hasAttribute.call(element, 'disabled');
+        }
+        return true;
+    });
 }
-
-const DidAddMouseEventListeners = new WeakMap(); // Due to browser differences, it is impossible to know what is focusable until
+const DidAddMouseEventListeners = new WeakMap();
+// Due to browser differences, it is impossible to know what is focusable until
 // we actually try to focus it. We need to refactor our focus delegation logic
 // to verify whether or not the target was actually focused instead of trying
 // to predict focusability like we do here.
-
 function isVisible(element) {
-  const {
-    width,
-    height
-  } = getBoundingClientRect.call(element);
-  const noZeroSize = width > 0 || height > 0; // The area element can be 0x0 and focusable. Hardcoding this is not ideal
-  // but it will minimize changes in the current behavior.
-
-  const isAreaElement = element.tagName === 'AREA';
-  return (noZeroSize || isAreaElement) && getComputedStyle(element).visibility !== 'hidden';
-} // This function based on https://allyjs.io/data-tables/focusable.html
+    const { width, height } = getBoundingClientRect.call(element);
+    const noZeroSize = width > 0 || height > 0;
+    // The area element can be 0x0 and focusable. Hardcoding this is not ideal
+    // but it will minimize changes in the current behavior.
+    const isAreaElement = element.tagName === 'AREA';
+    return (noZeroSize || isAreaElement) && getComputedStyle(element).visibility !== 'hidden';
+}
+// This function based on https://allyjs.io/data-tables/focusable.html
 // It won't catch everything, but should be good enough
 // There are a lot of edge cases here that we can't realistically handle
 // Determines if a particular element is tabbable, as opposed to simply focusable
-
-
 function isTabbable(element) {
-  if (isSyntheticShadowHost(element) && isDelegatingFocus(element)) {
-    return false;
-  }
-
-  return matches.call(element, FocusableSelector) && isVisible(element);
-}
-
-function hostElementFocus() {
-  const _rootNode = this.getRootNode();
-
-  if (_rootNode === this) {
-    // We invoke the focus() method even if the host is disconnected in order to eliminate
-    // observable differences for component authors between synthetic and native.
-    const focusable = querySelector.call(this, FocusableSelector);
-
-    if (!isNull(focusable)) {
-      // @ts-ignore type-mismatch
-      focusable.focus.apply(focusable, arguments);
+    if (isSyntheticShadowHost(element) && isDelegatingFocus(element)) {
+        return false;
     }
-
-    return;
-  } // If the root node is not the host element then it's either the document or a shadow root.
-
-
-  const rootNode = _rootNode;
-
-  if (rootNode.activeElement === this) {
-    // The focused element should not change if the focus method is invoked
-    // on the shadow-including ancestor of the currently focused element.
-    return;
-  }
-
-  const focusables = arrayFromCollection(querySelectorAll$1.call(this, FocusableSelector));
-  let didFocus = false;
-
-  while (!didFocus && focusables.length !== 0) {
-    const focusable = focusables.shift(); // @ts-ignore type-mismatch
-
-    focusable.focus.apply(focusable, arguments); // Get the root node of the current focusable in case it was slotted.
-
-    const currentRootNode = focusable.getRootNode();
-    didFocus = currentRootNode.activeElement === focusable;
-  }
+    return matches.call(element, FocusableSelector) && isVisible(element);
 }
-
+function hostElementFocus() {
+    const _rootNode = this.getRootNode();
+    if (_rootNode === this) {
+        // We invoke the focus() method even if the host is disconnected in order to eliminate
+        // observable differences for component authors between synthetic and native.
+        const focusable = querySelector.call(this, FocusableSelector);
+        if (!isNull(focusable)) {
+            // @ts-ignore type-mismatch
+            focusable.focus.apply(focusable, arguments);
+        }
+        return;
+    }
+    // If the root node is not the host element then it's either the document or a shadow root.
+    const rootNode = _rootNode;
+    if (rootNode.activeElement === this) {
+        // The focused element should not change if the focus method is invoked
+        // on the shadow-including ancestor of the currently focused element.
+        return;
+    }
+    const focusables = arrayFromCollection(querySelectorAll$1.call(this, FocusableSelector));
+    let didFocus = false;
+    while (!didFocus && focusables.length !== 0) {
+        const focusable = focusables.shift();
+        // @ts-ignore type-mismatch
+        focusable.focus.apply(focusable, arguments);
+        // Get the root node of the current focusable in case it was slotted.
+        const currentRootNode = focusable.getRootNode();
+        didFocus = currentRootNode.activeElement === focusable;
+    }
+}
 function getTabbableSegments(host) {
-  const doc = getOwnerDocument(host);
-  const all = filterSequentiallyFocusableElements(arrayFromCollection(querySelectorAll.call(doc, FocusableSelector)));
-  const inner = filterSequentiallyFocusableElements(arrayFromCollection(querySelectorAll$1.call(host, FocusableSelector)));
-
-  if (true) {
-    assert.invariant(getAttribute.call(host, 'tabindex') === '-1' || isDelegatingFocus(host), `The focusin event is only relevant when the tabIndex property is -1 on the host.`);
-  }
-
-  const firstChild = inner[0];
-  const lastChild = inner[inner.length - 1];
-  const hostIndex = ArrayIndexOf.call(all, host); // Host element can show up in our "previous" section if its tabindex is 0
-  // We want to filter that out here
-
-  const firstChildIndex = hostIndex > -1 ? hostIndex : ArrayIndexOf.call(all, firstChild); // Account for an empty inner list
-
-  const lastChildIndex = inner.length === 0 ? firstChildIndex + 1 : ArrayIndexOf.call(all, lastChild) + 1;
-  const prev = ArraySlice.call(all, 0, firstChildIndex);
-  const next = ArraySlice.call(all, lastChildIndex);
-  return {
-    prev,
-    inner,
-    next
-  };
+    const doc = getOwnerDocument(host);
+    const all = filterSequentiallyFocusableElements(arrayFromCollection(querySelectorAll.call(doc, FocusableSelector)));
+    const inner = filterSequentiallyFocusableElements(arrayFromCollection(querySelectorAll$1.call(host, FocusableSelector)));
+    if (true) {
+        assert.invariant(getAttribute.call(host, 'tabindex') === '-1' || isDelegatingFocus(host), `The focusin event is only relevant when the tabIndex property is -1 on the host.`);
+    }
+    const firstChild = inner[0];
+    const lastChild = inner[inner.length - 1];
+    const hostIndex = ArrayIndexOf.call(all, host);
+    // Host element can show up in our "previous" section if its tabindex is 0
+    // We want to filter that out here
+    const firstChildIndex = hostIndex > -1 ? hostIndex : ArrayIndexOf.call(all, firstChild);
+    // Account for an empty inner list
+    const lastChildIndex = inner.length === 0 ? firstChildIndex + 1 : ArrayIndexOf.call(all, lastChild) + 1;
+    const prev = ArraySlice.call(all, 0, firstChildIndex);
+    const next = ArraySlice.call(all, lastChildIndex);
+    return {
+        prev,
+        inner,
+        next,
+    };
 }
-
 function getActiveElement(host) {
-  const doc = getOwnerDocument(host);
-  const activeElement = DocumentPrototypeActiveElement.call(doc);
-
-  if (isNull(activeElement)) {
-    return activeElement;
-  } // activeElement must be child of the host and owned by it
-
-
-  return (compareDocumentPosition.call(host, activeElement) & DOCUMENT_POSITION_CONTAINED_BY) !== 0 ? activeElement : null;
+    const doc = getOwnerDocument(host);
+    const activeElement = DocumentPrototypeActiveElement.call(doc);
+    if (isNull(activeElement)) {
+        return activeElement;
+    }
+    // activeElement must be child of the host and owned by it
+    return (compareDocumentPosition.call(host, activeElement) & DOCUMENT_POSITION_CONTAINED_BY) !==
+        0
+        ? activeElement
+        : null;
 }
-
 function relatedTargetPosition(host, relatedTarget) {
-  // assert: target must be child of host
-  const pos = compareDocumentPosition.call(host, relatedTarget);
-
-  if (pos & DOCUMENT_POSITION_CONTAINED_BY) {
-    // focus remains inside the host
-    return 0;
-  } else if (pos & DOCUMENT_POSITION_PRECEDING) {
-    // focus is coming from above
-    return 1;
-  } else if (pos & DOCUMENT_POSITION_FOLLOWING) {
-    // focus is coming from below
-    return 2;
-  } // we don't know what's going on.
-
-
-  return -1;
+    // assert: target must be child of host
+    const pos = compareDocumentPosition.call(host, relatedTarget);
+    if (pos & DOCUMENT_POSITION_CONTAINED_BY) {
+        // focus remains inside the host
+        return 0;
+    }
+    else if (pos & DOCUMENT_POSITION_PRECEDING) {
+        // focus is coming from above
+        return 1;
+    }
+    else if (pos & DOCUMENT_POSITION_FOLLOWING) {
+        // focus is coming from below
+        return 2;
+    }
+    // we don't know what's going on.
+    return -1;
 }
-
 function muteEvent(event) {
-  event.preventDefault();
-  event.stopPropagation();
+    event.preventDefault();
+    event.stopPropagation();
 }
-
 function muteFocusEventsDuringExecution(win, func) {
-  windowAddEventListener.call(win, 'focusin', muteEvent, true);
-  windowAddEventListener.call(win, 'focusout', muteEvent, true);
-  func();
-  windowRemoveEventListener.call(win, 'focusin', muteEvent, true);
-  windowRemoveEventListener.call(win, 'focusout', muteEvent, true);
+    windowAddEventListener.call(win, 'focusin', muteEvent, true);
+    windowAddEventListener.call(win, 'focusout', muteEvent, true);
+    func();
+    windowRemoveEventListener.call(win, 'focusin', muteEvent, true);
+    windowRemoveEventListener.call(win, 'focusout', muteEvent, true);
 }
-
 function focusOnNextOrBlur(segment, target, relatedTarget) {
-  const win = getOwnerWindow(relatedTarget);
-  const next = getNextTabbable(segment, relatedTarget);
-
-  if (isNull(next)) {
-    // nothing to focus on, blur to invalidate the operation
-    muteFocusEventsDuringExecution(win, () => {
-      target.blur();
-    });
-  } else {
-    muteFocusEventsDuringExecution(win, () => {
-      next.focus();
-    });
-  }
+    const win = getOwnerWindow(relatedTarget);
+    const next = getNextTabbable(segment, relatedTarget);
+    if (isNull(next)) {
+        // nothing to focus on, blur to invalidate the operation
+        muteFocusEventsDuringExecution(win, () => {
+            target.blur();
+        });
+    }
+    else {
+        muteFocusEventsDuringExecution(win, () => {
+            next.focus();
+        });
+    }
 }
-
 let letBrowserHandleFocus = false;
 function disableKeyboardFocusNavigationRoutines() {
-  letBrowserHandleFocus = true;
+    letBrowserHandleFocus = true;
 }
 function enableKeyboardFocusNavigationRoutines() {
-  letBrowserHandleFocus = false;
+    letBrowserHandleFocus = false;
 }
 function isKeyboardFocusNavigationRoutineEnabled() {
-  return !letBrowserHandleFocus;
+    return !letBrowserHandleFocus;
 }
-
 function skipHostHandler(event) {
-  if (letBrowserHandleFocus) {
-    return;
-  }
-
-  const host = eventCurrentTargetGetter.call(event);
-  const target = eventTargetGetter.call(event); // If the host delegating focus with tabindex=0 is not the target, we know
-  // that the event was dispatched on a descendant node of the host. This
-  // means the focus is coming from below and we don't need to do anything.
-
-  if (host !== target) {
-    // Focus is coming from above
-    return;
-  }
-
-  const relatedTarget = focusEventRelatedTargetGetter.call(event);
-
-  if (isNull(relatedTarget)) {
-    // If relatedTarget is null, the user is most likely tabbing into the document from the
-    // browser chrome. We could probably deduce whether focus is coming in from the top or the
-    // bottom by comparing the position of the target to all tabbable elements. This is an edge
-    // case and only comes up if the custom element is the first or last tabbable element in the
-    // document.
-    return;
-  }
-
-  const segments = getTabbableSegments(host);
-  const position = relatedTargetPosition(host, relatedTarget);
-
-  if (position === 1) {
-    // Focus is coming from above
-    const findTabbableElms = isTabbableFrom.bind(null, host.getRootNode());
-    const first = ArrayFind.call(segments.inner, findTabbableElms);
-
-    if (!isUndefined(first)) {
-      const win = getOwnerWindow(first);
-      muteFocusEventsDuringExecution(win, () => {
-        first.focus();
-      });
-    } else {
-      focusOnNextOrBlur(segments.next, target, relatedTarget);
+    if (letBrowserHandleFocus) {
+        return;
     }
-  } else if (host === target) {
-    // Host is receiving focus from below, either from its shadow or from a sibling
-    focusOnNextOrBlur(ArrayReverse.call(segments.prev), target, relatedTarget);
-  }
+    const host = eventCurrentTargetGetter.call(event);
+    const target = eventTargetGetter.call(event);
+    // If the host delegating focus with tabindex=0 is not the target, we know
+    // that the event was dispatched on a descendant node of the host. This
+    // means the focus is coming from below and we don't need to do anything.
+    if (host !== target) {
+        // Focus is coming from above
+        return;
+    }
+    const relatedTarget = focusEventRelatedTargetGetter.call(event);
+    if (isNull(relatedTarget)) {
+        // If relatedTarget is null, the user is most likely tabbing into the document from the
+        // browser chrome. We could probably deduce whether focus is coming in from the top or the
+        // bottom by comparing the position of the target to all tabbable elements. This is an edge
+        // case and only comes up if the custom element is the first or last tabbable element in the
+        // document.
+        return;
+    }
+    const segments = getTabbableSegments(host);
+    const position = relatedTargetPosition(host, relatedTarget);
+    if (position === 1) {
+        // Focus is coming from above
+        const findTabbableElms = isTabbableFrom.bind(null, host.getRootNode());
+        const first = ArrayFind.call(segments.inner, findTabbableElms);
+        if (!isUndefined(first)) {
+            const win = getOwnerWindow(first);
+            muteFocusEventsDuringExecution(win, () => {
+                first.focus();
+            });
+        }
+        else {
+            focusOnNextOrBlur(segments.next, target, relatedTarget);
+        }
+    }
+    else if (host === target) {
+        // Host is receiving focus from below, either from its shadow or from a sibling
+        focusOnNextOrBlur(ArrayReverse.call(segments.prev), target, relatedTarget);
+    }
 }
-
 function skipShadowHandler(event) {
-  if (letBrowserHandleFocus) {
-    return;
-  }
-
-  const relatedTarget = focusEventRelatedTargetGetter.call(event);
-
-  if (isNull(relatedTarget)) {
-    // If relatedTarget is null, the user is most likely tabbing into the document from the
-    // browser chrome. We could probably deduce whether focus is coming in from the top or the
-    // bottom by comparing the position of the target to all tabbable elements. This is an edge
-    // case and only comes up if the custom element is the first or last tabbable element in the
-    // document.
-    return;
-  }
-
-  const host = eventCurrentTargetGetter.call(event);
-  const segments = getTabbableSegments(host);
-
-  if (ArrayIndexOf.call(segments.inner, relatedTarget) !== -1) {
-    // If relatedTarget is contained by the host's subtree we can assume that the user is
-    // tabbing between elements inside of the shadow. Do nothing.
-    return;
-  }
-
-  const target = eventTargetGetter.call(event); // Determine where the focus is coming from (Tab or Shift+Tab)
-
-  const position = relatedTargetPosition(host, relatedTarget);
-
-  if (position === 1) {
-    // Focus is coming from above
-    focusOnNextOrBlur(segments.next, target, relatedTarget);
-  }
-
-  if (position === 2) {
-    // Focus is coming from below
-    focusOnNextOrBlur(ArrayReverse.call(segments.prev), target, relatedTarget);
-  }
-} // Use this function to determine whether you can start from one root and end up
-// at another element via tabbing.
-
-
-function isTabbableFrom(fromRoot, toElm) {
-  if (!isTabbable(toElm)) {
-    return false;
-  }
-
-  const ownerDocument = getOwnerDocument(toElm);
-  let root = toElm.getRootNode();
-
-  while (root !== ownerDocument && root !== fromRoot) {
-    const sr = root;
-    const host = sr.host;
-
-    if (getAttribute.call(host, 'tabindex') === '-1') {
-      return false;
+    if (letBrowserHandleFocus) {
+        return;
     }
-
-    root = host && host.getRootNode();
-  }
-
-  return true;
+    const relatedTarget = focusEventRelatedTargetGetter.call(event);
+    if (isNull(relatedTarget)) {
+        // If relatedTarget is null, the user is most likely tabbing into the document from the
+        // browser chrome. We could probably deduce whether focus is coming in from the top or the
+        // bottom by comparing the position of the target to all tabbable elements. This is an edge
+        // case and only comes up if the custom element is the first or last tabbable element in the
+        // document.
+        return;
+    }
+    const host = eventCurrentTargetGetter.call(event);
+    const segments = getTabbableSegments(host);
+    if (ArrayIndexOf.call(segments.inner, relatedTarget) !== -1) {
+        // If relatedTarget is contained by the host's subtree we can assume that the user is
+        // tabbing between elements inside of the shadow. Do nothing.
+        return;
+    }
+    const target = eventTargetGetter.call(event);
+    // Determine where the focus is coming from (Tab or Shift+Tab)
+    const position = relatedTargetPosition(host, relatedTarget);
+    if (position === 1) {
+        // Focus is coming from above
+        focusOnNextOrBlur(segments.next, target, relatedTarget);
+    }
+    if (position === 2) {
+        // Focus is coming from below
+        focusOnNextOrBlur(ArrayReverse.call(segments.prev), target, relatedTarget);
+    }
 }
-
-function getNextTabbable(tabbables, relatedTarget) {
-  const len = tabbables.length;
-
-  if (len > 0) {
-    for (let i = 0; i < len; i += 1) {
-      const next = tabbables[i];
-
-      if (isTabbableFrom(relatedTarget.getRootNode(), next)) {
-        return next;
-      }
+// Use this function to determine whether you can start from one root and end up
+// at another element via tabbing.
+function isTabbableFrom(fromRoot, toElm) {
+    if (!isTabbable(toElm)) {
+        return false;
     }
-  }
-
-  return null;
-} // Skips the host element
-
-
+    const ownerDocument = getOwnerDocument(toElm);
+    let root = toElm.getRootNode();
+    while (root !== ownerDocument && root !== fromRoot) {
+        const sr = root;
+        const host = sr.host;
+        if (getAttribute.call(host, 'tabindex') === '-1') {
+            return false;
+        }
+        root = host && host.getRootNode();
+    }
+    return true;
+}
+function getNextTabbable(tabbables, relatedTarget) {
+    const len = tabbables.length;
+    if (len > 0) {
+        for (let i = 0; i < len; i += 1) {
+            const next = tabbables[i];
+            if (isTabbableFrom(relatedTarget.getRootNode(), next)) {
+                return next;
+            }
+        }
+    }
+    return null;
+}
+// Skips the host element
 function handleFocus(elm) {
-  if (true) {
-    assert.invariant(isDelegatingFocus(elm), `Invalid attempt to handle focus event for ${toString(elm)}. ${toString(elm)} should have delegates focus true, but is not delegating focus`);
-  }
-
-  bindDocumentMousedownMouseupHandlers(elm); // Unbind any focusin listeners we may have going on
-
-  ignoreFocusIn(elm);
-  addEventListener.call(elm, 'focusin', skipHostHandler, true);
+    if (true) {
+        assert.invariant(isDelegatingFocus(elm), `Invalid attempt to handle focus event for ${toString(elm)}. ${toString(elm)} should have delegates focus true, but is not delegating focus`);
+    }
+    bindDocumentMousedownMouseupHandlers(elm);
+    // Unbind any focusin listeners we may have going on
+    ignoreFocusIn(elm);
+    addEventListener.call(elm, 'focusin', skipHostHandler, true);
 }
 function ignoreFocus(elm) {
-  removeEventListener.call(elm, 'focusin', skipHostHandler, true);
+    removeEventListener.call(elm, 'focusin', skipHostHandler, true);
 }
-
 function bindDocumentMousedownMouseupHandlers(elm) {
-  const ownerDocument = getOwnerDocument(elm);
-
-  if (!DidAddMouseEventListeners.get(ownerDocument)) {
-    DidAddMouseEventListeners.set(ownerDocument, true);
-    addEventListener.call(ownerDocument, 'mousedown', disableKeyboardFocusNavigationRoutines, true);
-    addEventListener.call(ownerDocument, 'mouseup', () => {
-      // We schedule this as an async task in the mouseup handler (as
-      // opposed to the mousedown handler) because we want to guarantee
-      // that it will never run before the focusin handler:
-      //
-      // Click form element   | Click form element label
-      // ==================================================
-      // mousedown            | mousedown
-      // FOCUSIN              | mousedown-setTimeout
-      // mousedown-setTimeout | mouseup
-      // mouseup              | FOCUSIN
-      // mouseup-setTimeout   | mouseup-setTimeout
-      setTimeout(enableKeyboardFocusNavigationRoutines);
-    }, true); // [W-7824445] If the element is draggable, the mousedown event is dispatched before the
-    // element is starting to be dragged, which disable the keyboard focus navigation routine.
-    // But by specification, the mouseup event is never dispatched once the element is dropped.
-    //
-    // For all draggable element, we need to add an event listener to re-enable the keyboard
-    // navigation routine after dragging starts.
-
-    addEventListener.call(ownerDocument, 'dragstart', enableKeyboardFocusNavigationRoutines, true);
-  }
-} // Skips the shadow tree
-
-
+    const ownerDocument = getOwnerDocument(elm);
+    if (!DidAddMouseEventListeners.get(ownerDocument)) {
+        DidAddMouseEventListeners.set(ownerDocument, true);
+        addEventListener.call(ownerDocument, 'mousedown', disableKeyboardFocusNavigationRoutines, true);
+        addEventListener.call(ownerDocument, 'mouseup', () => {
+            // We schedule this as an async task in the mouseup handler (as
+            // opposed to the mousedown handler) because we want to guarantee
+            // that it will never run before the focusin handler:
+            //
+            // Click form element   | Click form element label
+            // ==================================================
+            // mousedown            | mousedown
+            // FOCUSIN              | mousedown-setTimeout
+            // mousedown-setTimeout | mouseup
+            // mouseup              | FOCUSIN
+            // mouseup-setTimeout   | mouseup-setTimeout
+            setTimeout(enableKeyboardFocusNavigationRoutines);
+        }, true);
+        // [W-7824445] If the element is draggable, the mousedown event is dispatched before the
+        // element is starting to be dragged, which disable the keyboard focus navigation routine.
+        // But by specification, the mouseup event is never dispatched once the element is dropped.
+        //
+        // For all draggable element, we need to add an event listener to re-enable the keyboard
+        // navigation routine after dragging starts.
+        addEventListener.call(ownerDocument, 'dragstart', enableKeyboardFocusNavigationRoutines, true);
+    }
+}
+// Skips the shadow tree
 function handleFocusIn(elm) {
-  if (true) {
-    assert.invariant(tabIndexGetter.call(elm) === -1, `Invalid attempt to handle focus in  ${toString(elm)}. ${toString(elm)} should have tabIndex -1, but has tabIndex ${tabIndexGetter.call(elm)}`);
-  }
-
-  bindDocumentMousedownMouseupHandlers(elm); // Unbind any focus listeners we may have going on
-
-  ignoreFocus(elm); // This focusin listener is to catch focusin events from keyboard interactions
-  // A better solution would perhaps be to listen for keydown events, but
-  // the keydown event happens on whatever element already has focus (or no element
-  // at all in the case of the location bar. So, instead we have to assume that focusin
-  // without a mousedown means keyboard navigation
-
-  addEventListener.call(elm, 'focusin', skipShadowHandler, true);
+    if (true) {
+        assert.invariant(tabIndexGetter.call(elm) === -1, `Invalid attempt to handle focus in  ${toString(elm)}. ${toString(elm)} should have tabIndex -1, but has tabIndex ${tabIndexGetter.call(elm)}`);
+    }
+    bindDocumentMousedownMouseupHandlers(elm);
+    // Unbind any focus listeners we may have going on
+    ignoreFocus(elm);
+    // This focusin listener is to catch focusin events from keyboard interactions
+    // A better solution would perhaps be to listen for keydown events, but
+    // the keydown event happens on whatever element already has focus (or no element
+    // at all in the case of the location bar. So, instead we have to assume that focusin
+    // without a mousedown means keyboard navigation
+    addEventListener.call(elm, 'focusin', skipShadowHandler, true);
 }
 function ignoreFocusIn(elm) {
-  removeEventListener.call(elm, 'focusin', skipShadowHandler, true);
-}
-
-/*
- * Copyright (c) 2018, salesforce.com, inc.
- * All rights reserved.
- * SPDX-License-Identifier: MIT
- * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
- */
-
-function getElementComputedStyle(element) {
-  const win = getOwnerWindow(element);
-  return windowGetComputedStyle.call(win, element);
-}
-
-function getWindowSelection(node) {
-  const win = getOwnerWindow(node);
-  return windowGetSelection.call(win);
-}
-
-function nodeIsBeingRendered(nodeComputedStyle) {
-  return nodeComputedStyle.visibility === 'visible' && nodeComputedStyle.display !== 'none';
-}
-
-function getSelectionState(element) {
-  const win = getOwnerWindow(element);
-  const selection = getWindowSelection(element);
-
-  if (selection === null) {
-    return null;
-  }
-
-  const ranges = [];
-
-  for (let i = 0; i < selection.rangeCount; i++) {
-    ranges.push(selection.getRangeAt(i));
-  }
-
-  const state = {
-    element,
-    onselect: win.onselect,
-    onselectstart: win.onselectstart,
-    onselectionchange: win.onselectionchange,
-    ranges
-  };
-  win.onselect = null;
-  win.onselectstart = null;
-  win.onselectionchange = null;
-  return state;
-}
-
-function restoreSelectionState(state) {
-  if (state === null) {
-    return;
-  }
-
-  const {
-    element,
-    onselect,
-    onselectstart,
-    onselectionchange,
-    ranges
-  } = state;
-  const win = getOwnerWindow(element);
-  const selection = getWindowSelection(element);
-  selection.removeAllRanges();
-
-  for (let i = 0; i < ranges.length; i++) {
-    selection.addRange(ranges[i]);
-  }
-
-  win.onselect = onselect;
-  win.onselectstart = onselectstart;
-  win.onselectionchange = onselectionchange;
-}
-/**
- * Gets the "innerText" of a text node using the Selection API
- *
- * NOTE: For performance reasons, since this function will be called multiple times while calculating the innerText of
- *       an element, it does not restore the current selection.
- */
-
-
-function getTextNodeInnerText(textNode) {
-  const selection = getWindowSelection(textNode);
-
-  if (selection === null) {
-    return textNode.textContent || '';
-  }
-
-  const range = document.createRange();
-  range.selectNodeContents(textNode);
-  const domRect = range.getBoundingClientRect();
-
-  if (domRect.height <= 0 || domRect.width <= 0) {
-    // the text node is not rendered
-    return '';
-  } // Needed to remove non rendered characters from the text node.
-
-
-  selection.removeAllRanges();
-  selection.addRange(range);
-  const selectionText = selection.toString(); // The textNode is visible, but it may not be selectable. When the text is not selectable,
-  // textContent is the nearest approximation to innerText.
-
-  return selectionText ? selectionText : textNode.textContent || '';
-}
-
-const nodeIsElement = node => node.nodeType === ELEMENT_NODE;
-
-const nodeIsText = node => node.nodeType === TEXT_NODE;
-/**
- * Spec: https://html.spec.whatwg.org/multipage/dom.html#inner-text-collection-steps
- * One spec implementation: https://github.com/servo/servo/blob/721271dcd3c20db5ca8cf146e2b5907647afb4d6/components/layout/query.rs#L1132
- */
-
-
-function innerTextCollectionSteps(node) {
-  const items = [];
-
-  if (nodeIsElement(node)) {
-    const {
-      tagName
-    } = node;
-    const computedStyle = getElementComputedStyle(node);
-
-    if (tagName === 'OPTION') {
-      // For options, is hard to get the "rendered" text, let's use the original getter.
-      return [1, innerTextGetter.call(node), 1];
-    } else if (tagName === 'TEXTAREA') {
-      return [];
-    } else {
-      const childNodes = node.childNodes;
-
-      for (let i = 0, n = childNodes.length; i < n; i++) {
-        ArrayPush.apply(items, innerTextCollectionSteps(childNodes[i]));
-      }
-    }
-
-    if (!nodeIsBeingRendered(computedStyle)) {
-      if (tagName === 'SELECT' || tagName === 'DATALIST') {
-        // the select is either: .visibility != 'visible' or .display === hidden, therefore this select should
-        // not display any value.
-        return [];
-      }
-
-      return items;
-    }
-
-    if (tagName === 'BR') {
-      items.push('\u{000A}'
-      /* line feed */
-      );
-    }
-
-    const {
-      display
-    } = computedStyle;
-
-    if (display === 'table-cell') {
-      // omitting case: and node's CSS box is not the last 'table-cell' box of its enclosing 'table-row' box
-      items.push('\u{0009}'
-      /* tab */
-      );
-    }
-
-    if (display === 'table-row') {
-      // omitting case: and node's CSS box is not the last 'table-row' box of the nearest ancestor 'table' box
-      items.push('\u{000A}'
-      /* line feed */
-      );
-    }
-
-    if (tagName === 'P') {
-      items.unshift(2);
-      items.push(2);
-    }
-
-    if (display === 'block' || display === 'table-caption' || display === 'flex' || display === 'table') {
-      items.unshift(1);
-      items.push(1);
-    }
-  } else if (nodeIsText(node)) {
-    items.push(getTextNodeInnerText(node));
-  }
-
-  return items;
-}
-/**
- * InnerText getter spec: https://html.spec.whatwg.org/multipage/dom.html#the-innertext-idl-attribute
- *
- * One spec implementation: https://github.com/servo/servo/blob/721271dcd3c20db5ca8cf146e2b5907647afb4d6/components/layout/query.rs#L1087
- */
-
-
-function getInnerText(element) {
-  const thisComputedStyle = getElementComputedStyle(element);
-
-  if (!nodeIsBeingRendered(thisComputedStyle)) {
-    return getTextContent(element) || '';
-  }
-
-  const selectionState = getSelectionState(element);
-  const results = [];
-  const childNodes = element.childNodes;
-
-  for (let i = 0, n = childNodes.length; i < n; i++) {
-    ArrayPush.apply(results, innerTextCollectionSteps(childNodes[i]));
-  }
-
-  restoreSelectionState(selectionState);
-  let elementInnerText = '';
-  let maxReqLineBreakCount = 0;
-
-  for (let i = 0, n = results.length; i < n; i++) {
-    const item = results[i];
-
-    if (typeof item === 'string') {
-      if (maxReqLineBreakCount > 0) {
-        for (let j = 0; j < maxReqLineBreakCount; j++) {
-          elementInnerText += '\u{000A}';
-        }
-
-        maxReqLineBreakCount = 0;
-      }
-
-      if (item.length > 0) {
-        elementInnerText += item;
-      }
-    } else {
-      if (elementInnerText.length == 0) {
-        // Remove required line break count at the start.
-        continue;
-      } // Store the count if it's the max of this run,
-      // but it may be ignored if no text item is found afterwards,
-      // which means that these are consecutive line breaks at the end.
-
-
-      if (item > maxReqLineBreakCount) {
-        maxReqLineBreakCount = item;
-      }
-    }
-  }
-
-  return elementInnerText;
+    removeEventListener.call(elm, 'focusin', skipShadowHandler, true);
 }
 
 /*
@@ -5510,11 +4853,11 @@ defineProperties(HTMLElement.prototype, {
 if (innerTextGetter !== null && innerTextSetter !== null) {
   defineProperty(HTMLElement.prototype, 'innerText', {
     get() {
-      if (!runtimeFlags.ENABLE_INNER_OUTER_TEXT_PATCH) {
+      if (!lwcRuntimeFlags.ENABLE_INNER_OUTER_TEXT_PATCH) {
         return innerTextGetter.call(this);
       }
 
-      if (!runtimeFlags.ENABLE_ELEMENT_PATCH) {
+      if (!lwcRuntimeFlags.ENABLE_ELEMENT_PATCH) {
         if (isNodeShadowed(this) || isSyntheticShadowHost(this)) {
           return getInnerText(this);
         }
@@ -5546,11 +4889,11 @@ if (outerTextGetter !== null && outerTextSetter !== null) {
   // As a setter, it removes the current node and replaces it with the given text.
   defineProperty(HTMLElement.prototype, 'outerText', {
     get() {
-      if (!runtimeFlags.ENABLE_INNER_OUTER_TEXT_PATCH) {
+      if (!lwcRuntimeFlags.ENABLE_INNER_OUTER_TEXT_PATCH) {
         return outerTextGetter.call(this);
       }
 
-      if (!runtimeFlags.ENABLE_ELEMENT_PATCH) {
+      if (!lwcRuntimeFlags.ENABLE_ELEMENT_PATCH) {
         if (isNodeShadowed(this) || isSyntheticShadowHost(this)) {
           return getInnerText(this);
         }
@@ -5585,10 +4928,10 @@ if (outerTextGetter !== null && outerTextSetter !== null) {
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
 function getShadowToken(node) {
-  return node[KEY__SHADOW_TOKEN];
+    return node[KEY__SHADOW_TOKEN];
 }
 function setShadowToken(node, shadowToken) {
-  node[KEY__SHADOW_TOKEN] = shadowToken;
+    node[KEY__SHADOW_TOKEN] = shadowToken;
 }
 /**
  * Patching Element.prototype.$shadowToken$ to mark elements a portal:
@@ -5599,27 +4942,42 @@ function setShadowToken(node, shadowToken) {
  *  - this custom attribute must be unique.
  *
  **/
-
 defineProperty(Element.prototype, KEY__SHADOW_TOKEN, {
-  set(shadowToken) {
-    const oldShadowToken = this[KEY__SHADOW_TOKEN_PRIVATE];
-
-    if (!isUndefined(oldShadowToken) && oldShadowToken !== shadowToken) {
-      removeAttribute.call(this, oldShadowToken);
+    set(shadowToken) {
+        const oldShadowToken = this[KEY__SHADOW_TOKEN_PRIVATE];
+        if (!isUndefined(oldShadowToken) && oldShadowToken !== shadowToken) {
+            removeAttribute.call(this, oldShadowToken);
+        }
+        if (!isUndefined(shadowToken)) {
+            setAttribute.call(this, shadowToken, '');
+        }
+        this[KEY__SHADOW_TOKEN_PRIVATE] = shadowToken;
+    },
+    get() {
+        return this[KEY__SHADOW_TOKEN_PRIVATE];
+    },
+    configurable: true,
+});
+function recursivelySetShadowResolver(node, fn) {
+    node[KEY__SHADOW_RESOLVER] = fn;
+    const childNodes = childNodesGetter.call(node);
+    for (let i = 0, n = childNodes.length; i < n; i++) {
+        recursivelySetShadowResolver(childNodes[i], fn);
     }
-
-    if (!isUndefined(shadowToken)) {
-      setAttribute.call(this, shadowToken, '');
-    }
-
-    this[KEY__SHADOW_TOKEN_PRIVATE] = shadowToken;
-  },
-
-  get() {
-    return this[KEY__SHADOW_TOKEN_PRIVATE];
-  },
-
-  configurable: true
+}
+defineProperty(Element.prototype, KEY__SHADOW_STATIC, {
+    set(v) {
+        // Marking an element as static will propagate the shadow resolver to the children.
+        if (v) {
+            const fn = this[KEY__SHADOW_RESOLVER];
+            recursivelySetShadowResolver(this, fn);
+        }
+        this[KEY__SHADOW_STATIC_PRIVATE] = v;
+    },
+    get() {
+        return this[KEY__SHADOW_STATIC_PRIVATE];
+    },
+    configurable: true,
 });
 
 /*
@@ -5628,105 +4986,86 @@ defineProperty(Element.prototype, KEY__SHADOW_TOKEN, {
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
  */
-const DomManualPrivateKey = '$$DomManualKey$$'; // Resolver function used when a node is removed from within a portal
-
-const DocumentResolverFn = function () {}; // We can use a single observer without having to worry about leaking because
+const DomManualPrivateKey = '$$DomManualKey$$';
+// Resolver function used when a node is removed from within a portal
+const DocumentResolverFn = function () { };
+// We can use a single observer without having to worry about leaking because
 // "Registered observers in a node’s registered observer list have a weak
 // reference to the node."
 // https://dom.spec.whatwg.org/#garbage-collection
-
-
 let portalObserver;
 const portalObserverConfig = {
-  childList: true
+    childList: true,
 };
-
 function adoptChildNode(node, fn, shadowToken) {
-  const previousNodeShadowResolver = getShadowRootResolver(node);
-
-  if (previousNodeShadowResolver === fn) {
-    return; // nothing to do here, it is already correctly patched
-  }
-
-  setShadowRootResolver(node, fn);
-
-  if (node instanceof Element) {
-    setShadowToken(node, shadowToken);
-
-    if (isSyntheticShadowHost(node)) {
-      // Root LWC elements can't get content slotted into them, therefore we don't observe their children.
-      return;
+    const previousNodeShadowResolver = getShadowRootResolver(node);
+    if (previousNodeShadowResolver === fn) {
+        return; // nothing to do here, it is already correctly patched
     }
-
-    if (isUndefined(previousNodeShadowResolver)) {
-      // we only care about Element without shadowResolver (no MO.observe has been called)
-      MutationObserverObserve.call(portalObserver, node, portalObserverConfig);
-    } // recursively patching all children as well
-
-
-    const childNodes = childNodesGetter.call(node);
-
-    for (let i = 0, len = childNodes.length; i < len; i += 1) {
-      adoptChildNode(childNodes[i], fn, shadowToken);
+    setShadowRootResolver(node, fn);
+    if (node instanceof Element) {
+        setShadowToken(node, shadowToken);
+        if (isSyntheticShadowHost(node)) {
+            // Root LWC elements can't get content slotted into them, therefore we don't observe their children.
+            return;
+        }
+        if (isUndefined(previousNodeShadowResolver)) {
+            // we only care about Element without shadowResolver (no MO.observe has been called)
+            MutationObserverObserve.call(portalObserver, node, portalObserverConfig);
+        }
+        // recursively patching all children as well
+        const childNodes = childNodesGetter.call(node);
+        for (let i = 0, len = childNodes.length; i < len; i += 1) {
+            adoptChildNode(childNodes[i], fn, shadowToken);
+        }
     }
-  }
 }
-
 function initPortalObserver() {
-  return new MO(mutations => {
-    forEach.call(mutations, mutation => {
-      /**
-       * This routine will process all nodes added or removed from elm (which is marked as a portal)
-       * When adding a node to the portal element, we should add the ownership.
-       * When removing a node from the portal element, this ownership should be removed.
-       *
-       * There is some special cases in which MutationObserver may call with stacked mutations (the same node
-       * will be in addedNodes and removedNodes) or with false positives (a node that is removed and re-appended
-       * in the same tick) for those cases, we cover by checking that the node is contained
-       * (or not in the case of removal) by the element.
-       */
-      const {
-        target: elm,
-        addedNodes,
-        removedNodes
-      } = mutation; // the target of the mutation should always have a ShadowRootResolver attached to it
-
-      const fn = getShadowRootResolver(elm);
-      const shadowToken = getShadowToken(elm); // Process removals first to handle the case where an element is removed and reinserted
-
-      for (let i = 0, len = removedNodes.length; i < len; i += 1) {
-        const node = removedNodes[i];
-
-        if (!(compareDocumentPosition.call(elm, node) & _Node.DOCUMENT_POSITION_CONTAINED_BY)) {
-          adoptChildNode(node, DocumentResolverFn, undefined);
-        }
-      }
-
-      for (let i = 0, len = addedNodes.length; i < len; i += 1) {
-        const node = addedNodes[i];
-
-        if (compareDocumentPosition.call(elm, node) & _Node.DOCUMENT_POSITION_CONTAINED_BY) {
-          adoptChildNode(node, fn, shadowToken);
-        }
-      }
+    return new MO((mutations) => {
+        forEach.call(mutations, (mutation) => {
+            /**
+             * This routine will process all nodes added or removed from elm (which is marked as a portal)
+             * When adding a node to the portal element, we should add the ownership.
+             * When removing a node from the portal element, this ownership should be removed.
+             *
+             * There is some special cases in which MutationObserver may call with stacked mutations (the same node
+             * will be in addedNodes and removedNodes) or with false positives (a node that is removed and re-appended
+             * in the same tick) for those cases, we cover by checking that the node is contained
+             * (or not in the case of removal) by the element.
+             */
+            const { target: elm, addedNodes, removedNodes } = mutation;
+            // the target of the mutation should always have a ShadowRootResolver attached to it
+            const fn = getShadowRootResolver(elm);
+            const shadowToken = getShadowToken(elm);
+            // Process removals first to handle the case where an element is removed and reinserted
+            for (let i = 0, len = removedNodes.length; i < len; i += 1) {
+                const node = removedNodes[i];
+                if (!(compareDocumentPosition.call(elm, node) & _Node.DOCUMENT_POSITION_CONTAINED_BY)) {
+                    adoptChildNode(node, DocumentResolverFn, undefined);
+                }
+            }
+            for (let i = 0, len = addedNodes.length; i < len; i += 1) {
+                const node = addedNodes[i];
+                if (compareDocumentPosition.call(elm, node) & _Node.DOCUMENT_POSITION_CONTAINED_BY) {
+                    adoptChildNode(node, fn, shadowToken);
+                }
+            }
+        });
     });
-  });
 }
-
 function markElementAsPortal(elm) {
-  if (isUndefined(portalObserver)) {
-    portalObserver = initPortalObserver();
-  }
-
-  if (isUndefined(getShadowRootResolver(elm))) {
-    // only an element from a within a shadowRoot should be used here
-    throw new Error(`Invalid Element`);
-  } // install mutation observer for portals
-
-
-  MutationObserverObserve.call(portalObserver, elm, portalObserverConfig); // TODO [#1253]: optimization to synchronously adopt new child nodes added
-  // to this elm, we can do that by patching the most common operations
-  // on the node itself
+    if (isUndefined(portalObserver)) {
+        portalObserver = initPortalObserver();
+    }
+    if (isUndefined(getShadowRootResolver(elm))) {
+        // only an element from a within a shadowRoot should be used here
+        throw new Error(`Invalid Element`);
+    }
+    // install mutation observer for portals
+    MutationObserverObserve.call(portalObserver, elm, portalObserverConfig);
+    // TODO [#1253]: optimization to synchronously adopt new child nodes added
+    // to this elm, we can do that by patching the most common operations
+    // on the node itself
 }
 /**
  * Patching Element.prototype.$domManual$ to mark elements as portal:
@@ -5743,24 +5082,44 @@ function markElementAsPortal(elm) {
  *
  **/
 // TODO [#1306]: rename this to $observerConnection$
-
-
 defineProperty(Element.prototype, '$domManual$', {
-  set(v) {
-    this[DomManualPrivateKey] = v;
-
-    if (isTrue(v)) {
-      markElementAsPortal(this);
-    }
-  },
-
-  get() {
-    return this[DomManualPrivateKey];
-  },
-
-  configurable: true
+    set(v) {
+        this[DomManualPrivateKey] = v;
+        if (isTrue(v)) {
+            markElementAsPortal(this);
+        }
+    },
+    get() {
+        return this[DomManualPrivateKey];
+    },
+    configurable: true,
 });
-/** version: 2.5.10 */
+
+/*
+ * Copyright (c) 2018, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+// @ts-ignore
+
+if ( true && typeof __karma__ !== 'undefined') {
+  window.addEventListener('test-dummy-flag', () => {
+    let hasFlag = false;
+
+    if (lwcRuntimeFlags.DUMMY_TEST_FLAG) {
+      hasFlag = true;
+    }
+
+    window.dispatchEvent(new CustomEvent('has-dummy-flag', {
+      detail: {
+        package: '@lwc/synthetic-shadow',
+        hasFlag
+      }
+    }));
+  });
+}
+/** version: 2.23.2 */
 
 
 /***/ })

--- a/test/__snapshots__/aliases/can-import-wire-service-as-lwc-wire-service.expected.txt
+++ b/test/__snapshots__/aliases/can-import-wire-service-as-lwc-wire-service.expected.txt
@@ -21,7 +21,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 function isUndefined(obj) {
     return obj === undefined;
 }
-/** version: 2.5.10 */
+/** version: 2.23.2 */
 
 /*
  * Copyright (c) 2018, salesforce.com, inc.
@@ -199,7 +199,7 @@ class LegacyWireAdapterBridge {
 exports.ValueChangedEvent = ValueChangedEvent;
 exports.register = register;
 exports.registerWireService = registerWireService;
-/** version: 2.5.10 */
+/** version: 2.23.2 */
 
 
 /***/ })

--- a/test/__snapshots__/basic-test/component-with-HTML-CSS-and-JS.expected.txt
+++ b/test/__snapshots__/basic-test/component-with-HTML-CSS-and-JS.expected.txt
@@ -12,10 +12,11 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-function stylesheet(useActualHostSelector, token) {
+function stylesheet(token, useActualHostSelector, useNativeDirPseudoclass) {
   var shadowSelector = token ? ("[" + token + "]") : "";
   var hostSelector = token ? ("[" + token + "-host]") : "";
-  return ["h1", shadowSelector, " {color: chocolate;}"].join('');
+  return "h1" + shadowSelector + " {color: chocolate;}";
+  /*LWC compiler v2.23.2*/
 }
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ([stylesheet]);
 
@@ -31,32 +32,37 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-/* harmony import */ var _component_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./component.css */ "./test/fixtures/basic/x/component/component.css");
-/* harmony import */ var _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./component.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! lwc */ "lwc");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! lwc */ "lwc");
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _component_css__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./component.css */ "./test/fixtures/basic/x/component/component.css");
+/* harmony import */ var _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./component.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
 
 
 
 
 
+
+
+const $fragment1 = lwc__WEBPACK_IMPORTED_MODULE_0__.parseFragment`<h1${3}>hello world from a simple module</h1>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const {t: api_text, h: api_element} = $api;
-  return [api_element("h1", {
-    key: 0
-  }, [api_text("hello world from a simple module")])];
+  const {st: api_static_fragment} = $api;
+  return [api_static_fragment($fragment1(), 1)];
+  /*LWC compiler v2.23.2*/
 }
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_2__.registerTemplate)(tmpl));
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_0__.registerTemplate)(tmpl));
 tmpl.stylesheets = [];
 
 
-if (_component_css__WEBPACK_IMPORTED_MODULE_0__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_css__WEBPACK_IMPORTED_MODULE_0__["default"])
+if (_component_css__WEBPACK_IMPORTED_MODULE_1__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_css__WEBPACK_IMPORTED_MODULE_1__["default"])
 }
-if (_component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"])
+if (_component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"])
 }
-tmpl.stylesheetToken = "x-component_component"
+if (_component_css__WEBPACK_IMPORTED_MODULE_1__["default"] || _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheetToken = "x-component_component"
+}
+(0,lwc__WEBPACK_IMPORTED_MODULE_0__.freezeTemplate)(tmpl);
 
 
 /***/ }),
@@ -178,6 +184,8 @@ __webpack_require__.r(__webpack_exports__);
     super(...args);
     this.fooBarBaz = 'foo';
   }
+  /*LWC compiler v2.23.2*/
+
 
 }, {
   publicProps: {

--- a/test/__snapshots__/basic-test/component-with-implicit-CSS.expected.txt
+++ b/test/__snapshots__/basic-test/component-with-implicit-CSS.expected.txt
@@ -12,32 +12,37 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-/* harmony import */ var _component_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./component.css */ "./dist/mocks/empty-style.js");
-/* harmony import */ var _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./component.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! lwc */ "lwc");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! lwc */ "lwc");
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _component_css__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./component.css */ "./dist/mocks/empty-style.js");
+/* harmony import */ var _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./component.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
 
 
 
 
 
+
+
+const $fragment1 = lwc__WEBPACK_IMPORTED_MODULE_0__.parseFragment`<h1${3}>hello</h1>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const {t: api_text, h: api_element} = $api;
-  return [api_element("h1", {
-    key: 0
-  }, [api_text("hello")])];
+  const {st: api_static_fragment} = $api;
+  return [api_static_fragment($fragment1(), 1)];
+  /*LWC compiler v2.23.2*/
 }
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_2__.registerTemplate)(tmpl));
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_0__.registerTemplate)(tmpl));
 tmpl.stylesheets = [];
 
 
-if (_component_css__WEBPACK_IMPORTED_MODULE_0__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_css__WEBPACK_IMPORTED_MODULE_0__["default"])
+if (_component_css__WEBPACK_IMPORTED_MODULE_1__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_css__WEBPACK_IMPORTED_MODULE_1__["default"])
 }
-if (_component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"])
+if (_component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"])
 }
-tmpl.stylesheetToken = "x-component_component"
+if (_component_css__WEBPACK_IMPORTED_MODULE_1__["default"] || _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheetToken = "x-component_component"
+}
+(0,lwc__WEBPACK_IMPORTED_MODULE_0__.freezeTemplate)(tmpl);
 
 
 /***/ }),
@@ -173,7 +178,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_1__);
 
 
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_1__.registerComponent)(class extends lwc__WEBPACK_IMPORTED_MODULE_1__.LightningElement {}, {
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_1__.registerComponent)(class extends lwc__WEBPACK_IMPORTED_MODULE_1__.LightningElement {
+  /*LWC compiler v2.23.2*/
+}, {
   tmpl: _component_html__WEBPACK_IMPORTED_MODULE_0__["default"]
 }));
 })();

--- a/test/__snapshots__/basic-test/component-with-implicit-HTML.expected.txt
+++ b/test/__snapshots__/basic-test/component-with-implicit-HTML.expected.txt
@@ -118,6 +118,8 @@ __webpack_require__.r(__webpack_exports__);
   renderedCallback() {
     console.log('yolo');
   }
+  /*LWC compiler v2.23.2*/
+
 
 }, {
   tmpl: _component_html__WEBPACK_IMPORTED_MODULE_0__["default"]

--- a/test/__snapshots__/basic-test/component-with-multiple-templates.expected.txt
+++ b/test/__snapshots__/basic-test/component-with-multiple-templates.expected.txt
@@ -12,10 +12,11 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-function stylesheet(useActualHostSelector, token) {
+function stylesheet(token, useActualHostSelector, useNativeDirPseudoclass) {
   var shadowSelector = token ? ("[" + token + "]") : "";
   var hostSelector = token ? ("[" + token + "-host]") : "";
-  return ["h1", shadowSelector, " {color: chocolate;}"].join('');
+  return "h1" + shadowSelector + " {color: chocolate;}";
+  /*LWC compiler v2.23.2*/
 }
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ([stylesheet]);
 
@@ -31,32 +32,37 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-/* harmony import */ var _a_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./a.css */ "./test/fixtures/multi-template/x/component/a.css");
-/* harmony import */ var _a_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./a.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! lwc */ "lwc");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! lwc */ "lwc");
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _a_css__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./a.css */ "./test/fixtures/multi-template/x/component/a.css");
+/* harmony import */ var _a_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./a.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
 
 
 
 
 
+
+
+const $fragment1 = lwc__WEBPACK_IMPORTED_MODULE_0__.parseFragment`<h1${3}>a</h1>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const {t: api_text, h: api_element} = $api;
-  return [api_element("h1", {
-    key: 0
-  }, [api_text("a")])];
+  const {st: api_static_fragment} = $api;
+  return [api_static_fragment($fragment1(), 1)];
+  /*LWC compiler v2.23.2*/
 }
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_2__.registerTemplate)(tmpl));
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_0__.registerTemplate)(tmpl));
 tmpl.stylesheets = [];
 
 
-if (_a_css__WEBPACK_IMPORTED_MODULE_0__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _a_css__WEBPACK_IMPORTED_MODULE_0__["default"])
+if (_a_css__WEBPACK_IMPORTED_MODULE_1__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _a_css__WEBPACK_IMPORTED_MODULE_1__["default"])
 }
-if (_a_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _a_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"])
+if (_a_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _a_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"])
 }
-tmpl.stylesheetToken = "x-component_a"
+if (_a_css__WEBPACK_IMPORTED_MODULE_1__["default"] || _a_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheetToken = "x-component_a"
+}
+(0,lwc__WEBPACK_IMPORTED_MODULE_0__.freezeTemplate)(tmpl);
 
 
 /***/ }),
@@ -71,32 +77,37 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-/* harmony import */ var _b_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./b.css */ "./dist/mocks/empty-style.js");
-/* harmony import */ var _b_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./b.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! lwc */ "lwc");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! lwc */ "lwc");
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _b_css__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./b.css */ "./dist/mocks/empty-style.js");
+/* harmony import */ var _b_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./b.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
 
 
 
 
 
+
+
+const $fragment1 = lwc__WEBPACK_IMPORTED_MODULE_0__.parseFragment`<h1${3}>b</h1>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const {t: api_text, h: api_element} = $api;
-  return [api_element("h1", {
-    key: 0
-  }, [api_text("b")])];
+  const {st: api_static_fragment} = $api;
+  return [api_static_fragment($fragment1(), 1)];
+  /*LWC compiler v2.23.2*/
 }
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_2__.registerTemplate)(tmpl));
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_0__.registerTemplate)(tmpl));
 tmpl.stylesheets = [];
 
 
-if (_b_css__WEBPACK_IMPORTED_MODULE_0__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _b_css__WEBPACK_IMPORTED_MODULE_0__["default"])
+if (_b_css__WEBPACK_IMPORTED_MODULE_1__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _b_css__WEBPACK_IMPORTED_MODULE_1__["default"])
 }
-if (_b_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _b_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"])
+if (_b_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _b_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"])
 }
-tmpl.stylesheetToken = "x-component_b"
+if (_b_css__WEBPACK_IMPORTED_MODULE_1__["default"] || _b_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheetToken = "x-component_b"
+}
+(0,lwc__WEBPACK_IMPORTED_MODULE_0__.freezeTemplate)(tmpl);
 
 
 /***/ }),
@@ -247,6 +258,8 @@ __webpack_require__.r(__webpack_exports__);
     this.renderB = !this.renderB;
     return template;
   }
+  /*LWC compiler v2.23.2*/
+
 
 }, {
   publicProps: {

--- a/test/__snapshots__/basic-test/component-with-scoped-CSS.expected.txt
+++ b/test/__snapshots__/basic-test/component-with-scoped-CSS.expected.txt
@@ -12,32 +12,37 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-/* harmony import */ var _component_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./component.css */ "./dist/mocks/empty-style.js");
-/* harmony import */ var _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./component.scoped.css?scoped=true */ "./test/fixtures/scoped-css/x/component/component.scoped.css?scoped=true");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! lwc */ "lwc");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! lwc */ "lwc");
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _component_css__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./component.css */ "./dist/mocks/empty-style.js");
+/* harmony import */ var _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./component.scoped.css?scoped=true */ "./test/fixtures/scoped-css/x/component/component.scoped.css?scoped=true");
 
 
 
 
 
+
+
+const $fragment1 = lwc__WEBPACK_IMPORTED_MODULE_0__.parseFragment`<h1${3}>I am scoped</h1>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const {t: api_text, h: api_element} = $api;
-  return [api_element("h1", {
-    key: 0
-  }, [api_text("I am scoped")])];
+  const {st: api_static_fragment} = $api;
+  return [api_static_fragment($fragment1(), 1)];
+  /*LWC compiler v2.23.2*/
 }
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_2__.registerTemplate)(tmpl));
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_0__.registerTemplate)(tmpl));
 tmpl.stylesheets = [];
 
 
-if (_component_css__WEBPACK_IMPORTED_MODULE_0__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_css__WEBPACK_IMPORTED_MODULE_0__["default"])
+if (_component_css__WEBPACK_IMPORTED_MODULE_1__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_css__WEBPACK_IMPORTED_MODULE_1__["default"])
 }
-if (_component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"])
+if (_component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"])
 }
-tmpl.stylesheetToken = "x-component_component"
+if (_component_css__WEBPACK_IMPORTED_MODULE_1__["default"] || _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheetToken = "x-component_component"
+}
+(0,lwc__WEBPACK_IMPORTED_MODULE_0__.freezeTemplate)(tmpl);
 
 
 /***/ }),
@@ -52,10 +57,11 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-function stylesheet(useActualHostSelector, token) {
+function stylesheet(token, useActualHostSelector, useNativeDirPseudoclass) {
   var shadowSelector = token ? ("." + token) : "";
   var hostSelector = token ? ("." + token + "-host") : "";
-  return ["h1", shadowSelector, " {color: red;}"].join('');
+  return "h1" + shadowSelector + " {color: red;}";
+  /*LWC compiler v2.23.2*/
 }
 stylesheet.$scoped$ = true;
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ([stylesheet]);
@@ -174,7 +180,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_1__);
 
 
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_1__.registerComponent)(class extends lwc__WEBPACK_IMPORTED_MODULE_1__.LightningElement {}, {
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_1__.registerComponent)(class extends lwc__WEBPACK_IMPORTED_MODULE_1__.LightningElement {
+  /*LWC compiler v2.23.2*/
+}, {
   tmpl: _component_html__WEBPACK_IMPORTED_MODULE_0__["default"]
 }));
 })();

--- a/test/__snapshots__/basic-test/component-with-typescript.expected.txt
+++ b/test/__snapshots__/basic-test/component-with-typescript.expected.txt
@@ -12,10 +12,11 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-function stylesheet(useActualHostSelector, token) {
+function stylesheet(token, useActualHostSelector, useNativeDirPseudoclass) {
   var shadowSelector = token ? ("[" + token + "]") : "";
   var hostSelector = token ? ("[" + token + "-host]") : "";
-  return ["h1", shadowSelector, " {color: chocolate;}"].join('');
+  return "h1" + shadowSelector + " {color: chocolate;}";
+  /*LWC compiler v2.23.2*/
 }
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ([stylesheet]);
 
@@ -31,32 +32,37 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-/* harmony import */ var _component_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./component.css */ "./test/fixtures/typescript/x/component/component.css");
-/* harmony import */ var _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./component.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! lwc */ "lwc");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! lwc */ "lwc");
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _component_css__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./component.css */ "./test/fixtures/typescript/x/component/component.css");
+/* harmony import */ var _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./component.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
 
 
 
 
 
+
+
+const $fragment1 = lwc__WEBPACK_IMPORTED_MODULE_0__.parseFragment`<h1${3}>hello world from a simple module</h1>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const {t: api_text, h: api_element} = $api;
-  return [api_element("h1", {
-    key: 0
-  }, [api_text("hello world from a simple module")])];
+  const {st: api_static_fragment} = $api;
+  return [api_static_fragment($fragment1(), 1)];
+  /*LWC compiler v2.23.2*/
 }
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_2__.registerTemplate)(tmpl));
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_0__.registerTemplate)(tmpl));
 tmpl.stylesheets = [];
 
 
-if (_component_css__WEBPACK_IMPORTED_MODULE_0__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_css__WEBPACK_IMPORTED_MODULE_0__["default"])
+if (_component_css__WEBPACK_IMPORTED_MODULE_1__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_css__WEBPACK_IMPORTED_MODULE_1__["default"])
 }
-if (_component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"])
+if (_component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"])
 }
-tmpl.stylesheetToken = "x-component_component"
+if (_component_css__WEBPACK_IMPORTED_MODULE_1__["default"] || _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheetToken = "x-component_component"
+}
+(0,lwc__WEBPACK_IMPORTED_MODULE_0__.freezeTemplate)(tmpl);
 
 
 /***/ }),
@@ -178,6 +184,8 @@ __webpack_require__.r(__webpack_exports__);
     super(...args);
     this.fooBarBaz = 'foo';
   }
+  /*LWC compiler v2.23.2*/
+
 
 }, {
   publicProps: {

--- a/test/__snapshots__/config-test/lwc-config-json/basic-component-using-lwc-config-json.expected.txt
+++ b/test/__snapshots__/config-test/lwc-config-json/basic-component-using-lwc-config-json.expected.txt
@@ -12,10 +12,11 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-function stylesheet(useActualHostSelector, token) {
+function stylesheet(token, useActualHostSelector, useNativeDirPseudoclass) {
   var shadowSelector = token ? ("[" + token + "]") : "";
   var hostSelector = token ? ("[" + token + "-host]") : "";
-  return ["h1", shadowSelector, " {color: chocolate;}"].join('');
+  return "h1" + shadowSelector + " {color: chocolate;}";
+  /*LWC compiler v2.23.2*/
 }
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ([stylesheet]);
 
@@ -31,32 +32,37 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-/* harmony import */ var _component_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./component.css */ "./test/fixtures/basic/x/component/component.css");
-/* harmony import */ var _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./component.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! lwc */ "lwc");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! lwc */ "lwc");
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _component_css__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./component.css */ "./test/fixtures/basic/x/component/component.css");
+/* harmony import */ var _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./component.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
 
 
 
 
 
+
+
+const $fragment1 = lwc__WEBPACK_IMPORTED_MODULE_0__.parseFragment`<h1${3}>hello world from a simple module</h1>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const {t: api_text, h: api_element} = $api;
-  return [api_element("h1", {
-    key: 0
-  }, [api_text("hello world from a simple module")])];
+  const {st: api_static_fragment} = $api;
+  return [api_static_fragment($fragment1(), 1)];
+  /*LWC compiler v2.23.2*/
 }
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_2__.registerTemplate)(tmpl));
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_0__.registerTemplate)(tmpl));
 tmpl.stylesheets = [];
 
 
-if (_component_css__WEBPACK_IMPORTED_MODULE_0__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_css__WEBPACK_IMPORTED_MODULE_0__["default"])
+if (_component_css__WEBPACK_IMPORTED_MODULE_1__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_css__WEBPACK_IMPORTED_MODULE_1__["default"])
 }
-if (_component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"])
+if (_component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"])
 }
-tmpl.stylesheetToken = "x-component_component"
+if (_component_css__WEBPACK_IMPORTED_MODULE_1__["default"] || _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheetToken = "x-component_component"
+}
+(0,lwc__WEBPACK_IMPORTED_MODULE_0__.freezeTemplate)(tmpl);
 
 
 /***/ }),
@@ -178,6 +184,8 @@ __webpack_require__.r(__webpack_exports__);
     super(...args);
     this.fooBarBaz = 'foo';
   }
+  /*LWC compiler v2.23.2*/
+
 
 }, {
   publicProps: {

--- a/test/__snapshots__/config-test/lwc-key-in-package-json/basic-component-using-lwc-config-json.expected.txt
+++ b/test/__snapshots__/config-test/lwc-key-in-package-json/basic-component-using-lwc-config-json.expected.txt
@@ -12,10 +12,11 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-function stylesheet(useActualHostSelector, token) {
+function stylesheet(token, useActualHostSelector, useNativeDirPseudoclass) {
   var shadowSelector = token ? ("[" + token + "]") : "";
   var hostSelector = token ? ("[" + token + "-host]") : "";
-  return ["h1", shadowSelector, " {color: chocolate;}"].join('');
+  return "h1" + shadowSelector + " {color: chocolate;}";
+  /*LWC compiler v2.23.2*/
 }
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ([stylesheet]);
 
@@ -31,32 +32,37 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-/* harmony import */ var _component_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./component.css */ "./test/fixtures/basic/x/component/component.css");
-/* harmony import */ var _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./component.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! lwc */ "lwc");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! lwc */ "lwc");
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _component_css__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./component.css */ "./test/fixtures/basic/x/component/component.css");
+/* harmony import */ var _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./component.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
 
 
 
 
 
+
+
+const $fragment1 = lwc__WEBPACK_IMPORTED_MODULE_0__.parseFragment`<h1${3}>hello world from a simple module</h1>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const {t: api_text, h: api_element} = $api;
-  return [api_element("h1", {
-    key: 0
-  }, [api_text("hello world from a simple module")])];
+  const {st: api_static_fragment} = $api;
+  return [api_static_fragment($fragment1(), 1)];
+  /*LWC compiler v2.23.2*/
 }
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_2__.registerTemplate)(tmpl));
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_0__.registerTemplate)(tmpl));
 tmpl.stylesheets = [];
 
 
-if (_component_css__WEBPACK_IMPORTED_MODULE_0__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_css__WEBPACK_IMPORTED_MODULE_0__["default"])
+if (_component_css__WEBPACK_IMPORTED_MODULE_1__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_css__WEBPACK_IMPORTED_MODULE_1__["default"])
 }
-if (_component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"])
+if (_component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"])
 }
-tmpl.stylesheetToken = "x-component_component"
+if (_component_css__WEBPACK_IMPORTED_MODULE_1__["default"] || _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheetToken = "x-component_component"
+}
+(0,lwc__WEBPACK_IMPORTED_MODULE_0__.freezeTemplate)(tmpl);
 
 
 /***/ }),
@@ -178,6 +184,8 @@ __webpack_require__.r(__webpack_exports__);
     super(...args);
     this.fooBarBaz = 'foo';
   }
+  /*LWC compiler v2.23.2*/
+
 
 }, {
   publicProps: {

--- a/test/__snapshots__/modules-configuration-test/external-npm-package/works-with-an-external-lib-using-the-npm-key.expected.txt
+++ b/test/__snapshots__/modules-configuration-test/external-npm-package/works-with-an-external-lib-using-the-npm-key.expected.txt
@@ -12,32 +12,37 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-/* harmony import */ var _component_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./component.css */ "./dist/mocks/empty-style.js");
-/* harmony import */ var _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./component.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! lwc */ "lwc");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! lwc */ "lwc");
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _component_css__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./component.css */ "./dist/mocks/empty-style.js");
+/* harmony import */ var _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./component.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
 
 
 
 
 
+
+
+const $fragment1 = lwc__WEBPACK_IMPORTED_MODULE_0__.parseFragment`<h1${3}>I am external!</h1>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const {t: api_text, h: api_element} = $api;
-  return [api_element("h1", {
-    key: 0
-  }, [api_text("I am external!")])];
+  const {st: api_static_fragment} = $api;
+  return [api_static_fragment($fragment1(), 1)];
+  /*LWC compiler v2.23.2*/
 }
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_2__.registerTemplate)(tmpl));
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_0__.registerTemplate)(tmpl));
 tmpl.stylesheets = [];
 
 
-if (_component_css__WEBPACK_IMPORTED_MODULE_0__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_css__WEBPACK_IMPORTED_MODULE_0__["default"])
+if (_component_css__WEBPACK_IMPORTED_MODULE_1__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_css__WEBPACK_IMPORTED_MODULE_1__["default"])
 }
-if (_component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"])
+if (_component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"])
 }
-tmpl.stylesheetToken = "y-component_component"
+if (_component_css__WEBPACK_IMPORTED_MODULE_1__["default"] || _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheetToken = "y-component_component"
+}
+(0,lwc__WEBPACK_IMPORTED_MODULE_0__.freezeTemplate)(tmpl);
 
 
 /***/ }),
@@ -57,7 +62,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_1__);
 
 
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_1__.registerComponent)(class extends lwc__WEBPACK_IMPORTED_MODULE_1__.LightningElement {}, {
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_1__.registerComponent)(class extends lwc__WEBPACK_IMPORTED_MODULE_1__.LightningElement {
+  /*LWC compiler v2.23.2*/
+}, {
   tmpl: _component_html__WEBPACK_IMPORTED_MODULE_0__["default"]
 }));
 ;
@@ -74,34 +81,41 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-/* harmony import */ var _component_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./component.css */ "./dist/mocks/empty-style.js");
-/* harmony import */ var _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./component.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
-/* harmony import */ var y_component__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! y/component */ "./node_modules/some-external-library/modules/y/component/component.js");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! lwc */ "lwc");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_3__);
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! lwc */ "lwc");
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _component_css__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./component.css */ "./dist/mocks/empty-style.js");
+/* harmony import */ var _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./component.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
+/* harmony import */ var y_component__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! y/component */ "./node_modules/some-external-library/modules/y/component/component.js");
 
 
 
 
 
 
+
+
+const stc0 = {
+  key: 0
+};
 function tmpl($api, $cmp, $slotset, $ctx) {
   const {c: api_custom_element} = $api;
-  return [api_custom_element("y-component", y_component__WEBPACK_IMPORTED_MODULE_2__["default"], {
-    key: 0
-  }, [])];
+  return [api_custom_element("y-component", y_component__WEBPACK_IMPORTED_MODULE_3__["default"], stc0)];
+  /*LWC compiler v2.23.2*/
 }
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_3__.registerTemplate)(tmpl));
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_0__.registerTemplate)(tmpl));
 tmpl.stylesheets = [];
 
 
-if (_component_css__WEBPACK_IMPORTED_MODULE_0__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_css__WEBPACK_IMPORTED_MODULE_0__["default"])
+if (_component_css__WEBPACK_IMPORTED_MODULE_1__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_css__WEBPACK_IMPORTED_MODULE_1__["default"])
 }
-if (_component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"])
+if (_component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"])
 }
-tmpl.stylesheetToken = "x-component_component"
+if (_component_css__WEBPACK_IMPORTED_MODULE_1__["default"] || _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheetToken = "x-component_component"
+}
+(0,lwc__WEBPACK_IMPORTED_MODULE_0__.freezeTemplate)(tmpl);
 
 
 /***/ }),
@@ -237,7 +251,9 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_1__);
 
 
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_1__.registerComponent)(class extends lwc__WEBPACK_IMPORTED_MODULE_1__.LightningElement {}, {
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_1__.registerComponent)(class extends lwc__WEBPACK_IMPORTED_MODULE_1__.LightningElement {
+  /*LWC compiler v2.23.2*/
+}, {
   tmpl: _component_html__WEBPACK_IMPORTED_MODULE_0__["default"]
 }));
 })();

--- a/test/__snapshots__/modules-configuration-test/works-with-modules-defined-with-the-alias-key.expected.txt
+++ b/test/__snapshots__/modules-configuration-test/works-with-modules-defined-with-the-alias-key.expected.txt
@@ -12,10 +12,11 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-function stylesheet(useActualHostSelector, token) {
+function stylesheet(token, useActualHostSelector, useNativeDirPseudoclass) {
   var shadowSelector = token ? ("[" + token + "]") : "";
   var hostSelector = token ? ("[" + token + "-host]") : "";
-  return ["h1", shadowSelector, " {color: chocolate;}"].join('');
+  return "h1" + shadowSelector + " {color: chocolate;}";
+  /*LWC compiler v2.23.2*/
 }
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ([stylesheet]);
 
@@ -31,32 +32,37 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ __webpack_require__.d(__webpack_exports__, {
 /* harmony export */   "default": () => (__WEBPACK_DEFAULT_EXPORT__)
 /* harmony export */ });
-/* harmony import */ var _component_css__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./component.css */ "./test/fixtures/basic/x/component/component.css");
-/* harmony import */ var _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./component.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! lwc */ "lwc");
-/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_2__);
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! lwc */ "lwc");
+/* harmony import */ var lwc__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__webpack_require__.n(lwc__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _component_css__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./component.css */ "./test/fixtures/basic/x/component/component.css");
+/* harmony import */ var _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./component.scoped.css?scoped=true */ "./dist/mocks/empty-style.js?scoped=true");
 
 
 
 
 
+
+
+const $fragment1 = lwc__WEBPACK_IMPORTED_MODULE_0__.parseFragment`<h1${3}>hello world from a simple module</h1>`;
 function tmpl($api, $cmp, $slotset, $ctx) {
-  const {t: api_text, h: api_element} = $api;
-  return [api_element("h1", {
-    key: 0
-  }, [api_text("hello world from a simple module")])];
+  const {st: api_static_fragment} = $api;
+  return [api_static_fragment($fragment1(), 1)];
+  /*LWC compiler v2.23.2*/
 }
-/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_2__.registerTemplate)(tmpl));
+/* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = ((0,lwc__WEBPACK_IMPORTED_MODULE_0__.registerTemplate)(tmpl));
 tmpl.stylesheets = [];
 
 
-if (_component_css__WEBPACK_IMPORTED_MODULE_0__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_css__WEBPACK_IMPORTED_MODULE_0__["default"])
+if (_component_css__WEBPACK_IMPORTED_MODULE_1__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_css__WEBPACK_IMPORTED_MODULE_1__["default"])
 }
-if (_component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"]) {
-  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_1__["default"])
+if (_component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheets.push.apply(tmpl.stylesheets, _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"])
 }
-tmpl.stylesheetToken = "x-component_component"
+if (_component_css__WEBPACK_IMPORTED_MODULE_1__["default"] || _component_scoped_css_scoped_true__WEBPACK_IMPORTED_MODULE_2__["default"]) {
+  tmpl.stylesheetToken = "x-component_component"
+}
+(0,lwc__WEBPACK_IMPORTED_MODULE_0__.freezeTemplate)(tmpl);
 
 
 /***/ }),
@@ -178,6 +184,8 @@ __webpack_require__.r(__webpack_exports__);
     super(...args);
     this.fooBarBaz = 'foo';
   }
+  /*LWC compiler v2.23.2*/
+
 
 }, {
   publicProps: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@ampproject/remapping@^2.1.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
+  integrity sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.1.0"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
 "@babel/code-frame@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.0.tgz#0dfc80309beec8411e65e706461c408b0bb9b431"
@@ -9,19 +17,24 @@
   dependencies:
     "@babel/highlight" "^7.16.0"
 
-"@babel/code-frame@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
-  integrity sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==
+"@babel/code-frame@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
+  integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
   dependencies:
-    "@babel/highlight" "^7.16.7"
+    "@babel/highlight" "^7.18.6"
 
 "@babel/compat-data@^7.16.0":
   version "7.16.4"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.16.4.tgz#081d6bbc336ec5c2435c6346b2ae1fb98b5ac68e"
   integrity sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==
 
-"@babel/core@^7.7.5", "@babel/core@~7.16.0":
+"@babel/compat-data@^7.18.8":
+  version "7.18.13"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.18.13.tgz#6aff7b350a1e8c3e40b029e46cbe78e24a913483"
+  integrity sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw==
+
+"@babel/core@^7.7.5":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.16.0.tgz#c4ff44046f5fe310525cc9eb4ef5147f0c5374d4"
   integrity sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==
@@ -42,6 +55,27 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
+"@babel/core@~7.18.13":
+  version "7.18.13"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.18.13.tgz#9be8c44512751b05094a4d3ab05fc53a47ce00ac"
+  integrity sha512-ZisbOvRRusFktksHSG6pjj1CSvkPkcZq/KHD45LAkVP/oiHJkNBZWfpvlLmX8OtHDG8IuzsFlVRWo08w7Qxn0A==
+  dependencies:
+    "@ampproject/remapping" "^2.1.0"
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.18.13"
+    "@babel/helper-compilation-targets" "^7.18.9"
+    "@babel/helper-module-transforms" "^7.18.9"
+    "@babel/helpers" "^7.18.9"
+    "@babel/parser" "^7.18.13"
+    "@babel/template" "^7.18.10"
+    "@babel/traverse" "^7.18.13"
+    "@babel/types" "^7.18.13"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.1"
+    semver "^6.3.0"
+
 "@babel/generator@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.16.0.tgz#d40f3d1d5075e62d3500bccb67f3daa8a95265b2"
@@ -51,28 +85,21 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.17.3":
-  version "7.17.7"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.17.7.tgz#8da2599beb4a86194a3b24df6c085931d9ee45ad"
-  integrity sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==
+"@babel/generator@^7.18.13":
+  version "7.18.13"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.13.tgz#59550cbb9ae79b8def15587bdfbaa388c4abf212"
+  integrity sha512-CkPg8ySSPuHTYPJYo7IRALdqyjM9HCbt/3uOBEFbzyGVP6Mn8bwFPB0jX6982JVNBlYzM1nnPkfjuXSOPtQeEQ==
   dependencies:
-    "@babel/types" "^7.17.0"
+    "@babel/types" "^7.18.13"
+    "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
-    source-map "^0.5.0"
 
-"@babel/helper-annotate-as-pure@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz#9a1f0ebcda53d9a2d00108c4ceace6a5d5f1f08d"
-  integrity sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==
+"@babel/helper-annotate-as-pure@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz#eaa49f6f80d5a33f9a5dd2276e6d6e451be0a6bb"
+  integrity sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==
   dependencies:
-    "@babel/types" "^7.16.0"
-
-"@babel/helper-annotate-as-pure@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz#bb2339a7534a9c128e3102024c60760a3a7f3862"
-  integrity sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==
-  dependencies:
-    "@babel/types" "^7.16.7"
+    "@babel/types" "^7.18.6"
 
 "@babel/helper-compilation-targets@^7.16.0":
   version "7.16.3"
@@ -84,37 +111,33 @@
     browserslist "^4.17.5"
     semver "^6.3.0"
 
-"@babel/helper-create-class-features-plugin@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.0.tgz#090d4d166b342a03a9fec37ef4fd5aeb9c7c6a4b"
-  integrity sha512-XLwWvqEaq19zFlF5PTgOod4bUA+XbkR4WLQBct1bkzmxJGB0ZEJaoKF4c8cgH9oBtCDuYJ8BP5NB9uFiEgO5QA==
+"@babel/helper-compilation-targets@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz#69e64f57b524cde3e5ff6cc5a9f4a387ee5563bf"
+  integrity sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.16.0"
-    "@babel/helper-function-name" "^7.16.0"
-    "@babel/helper-member-expression-to-functions" "^7.16.0"
-    "@babel/helper-optimise-call-expression" "^7.16.0"
-    "@babel/helper-replace-supers" "^7.16.0"
-    "@babel/helper-split-export-declaration" "^7.16.0"
+    "@babel/compat-data" "^7.18.8"
+    "@babel/helper-validator-option" "^7.18.6"
+    browserslist "^4.20.2"
+    semver "^6.3.0"
 
-"@babel/helper-create-class-features-plugin@^7.16.7":
-  version "7.17.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.6.tgz#3778c1ed09a7f3e65e6d6e0f6fbfcc53809d92c9"
-  integrity sha512-SogLLSxXm2OkBbSsHZMM4tUi8fUzjs63AT/d0YQIzr6GSd8Hxsbk2KYDX0k0DweAzGMj/YWeiCsorIdtdcW8Eg==
+"@babel/helper-create-class-features-plugin@^7.18.6", "@babel/helper-create-class-features-plugin@^7.18.9":
+  version "7.18.13"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.13.tgz#63e771187bd06d234f95fdf8bd5f8b6429de6298"
+  integrity sha512-hDvXp+QYxSRL+23mpAlSGxHMDyIGChm0/AwTfTAAK5Ufe40nCsyNdaYCGuK91phn/fVu9kqayImRDkvNAgdrsA==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.16.7"
-    "@babel/helper-environment-visitor" "^7.16.7"
-    "@babel/helper-function-name" "^7.16.7"
-    "@babel/helper-member-expression-to-functions" "^7.16.7"
-    "@babel/helper-optimise-call-expression" "^7.16.7"
-    "@babel/helper-replace-supers" "^7.16.7"
-    "@babel/helper-split-export-declaration" "^7.16.7"
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.18.9"
+    "@babel/helper-member-expression-to-functions" "^7.18.9"
+    "@babel/helper-optimise-call-expression" "^7.18.6"
+    "@babel/helper-replace-supers" "^7.18.9"
+    "@babel/helper-split-export-declaration" "^7.18.6"
 
-"@babel/helper-environment-visitor@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz#ff484094a839bde9d89cd63cba017d7aae80ecd7"
-  integrity sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==
-  dependencies:
-    "@babel/types" "^7.16.7"
+"@babel/helper-environment-visitor@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
+  integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
 
 "@babel/helper-function-name@^7.16.0":
   version "7.16.0"
@@ -125,14 +148,13 @@
     "@babel/template" "^7.16.0"
     "@babel/types" "^7.16.0"
 
-"@babel/helper-function-name@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz#f1ec51551fb1c8956bc8dd95f38523b6cf375f8f"
-  integrity sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==
+"@babel/helper-function-name@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz#940e6084a55dee867d33b4e487da2676365e86b0"
+  integrity sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==
   dependencies:
-    "@babel/helper-get-function-arity" "^7.16.7"
-    "@babel/template" "^7.16.7"
-    "@babel/types" "^7.16.7"
+    "@babel/template" "^7.18.6"
+    "@babel/types" "^7.18.9"
 
 "@babel/helper-get-function-arity@^7.16.0":
   version "7.16.0"
@@ -141,13 +163,6 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
-"@babel/helper-get-function-arity@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz#ea08ac753117a669f1508ba06ebcc49156387419"
-  integrity sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==
-  dependencies:
-    "@babel/types" "^7.16.7"
-
 "@babel/helper-hoist-variables@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz#4c9023c2f1def7e28ff46fc1dbcd36a39beaa81a"
@@ -155,12 +170,12 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
-"@babel/helper-hoist-variables@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz#86bcb19a77a509c7b77d0e22323ef588fa58c246"
-  integrity sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==
+"@babel/helper-hoist-variables@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz#d4d2c8fb4baeaa5c68b99cc8245c56554f926678"
+  integrity sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==
   dependencies:
-    "@babel/types" "^7.16.7"
+    "@babel/types" "^7.18.6"
 
 "@babel/helper-member-expression-to-functions@^7.16.0":
   version "7.16.0"
@@ -169,19 +184,26 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
-"@babel/helper-member-expression-to-functions@^7.16.7":
-  version "7.17.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.17.7.tgz#a34013b57d8542a8c4ff8ba3f747c02452a4d8c4"
-  integrity sha512-thxXgnQ8qQ11W2wVUObIqDL4p148VMxkt5T/qpN5k2fboRyzFGFmKsTGViquyM5QHKUy48OZoca8kw4ajaDPyw==
+"@babel/helper-member-expression-to-functions@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.18.9.tgz#1531661e8375af843ad37ac692c132841e2fd815"
+  integrity sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==
   dependencies:
-    "@babel/types" "^7.17.0"
+    "@babel/types" "^7.18.9"
 
-"@babel/helper-module-imports@^7.16.0", "@babel/helper-module-imports@~7.16.0":
+"@babel/helper-module-imports@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz#90538e60b672ecf1b448f5f4f5433d37e79a3ec3"
   integrity sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==
   dependencies:
     "@babel/types" "^7.16.0"
+
+"@babel/helper-module-imports@^7.18.6", "@babel/helper-module-imports@~7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz#1e3ebdbbd08aad1437b428c50204db13c5a3ca6e"
+  integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
+  dependencies:
+    "@babel/types" "^7.18.6"
 
 "@babel/helper-module-transforms@^7.16.0":
   version "7.16.0"
@@ -197,6 +219,20 @@
     "@babel/traverse" "^7.16.0"
     "@babel/types" "^7.16.0"
 
+"@babel/helper-module-transforms@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz#5a1079c005135ed627442df31a42887e80fcb712"
+  integrity sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-module-imports" "^7.18.6"
+    "@babel/helper-simple-access" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/helper-validator-identifier" "^7.18.6"
+    "@babel/template" "^7.18.6"
+    "@babel/traverse" "^7.18.9"
+    "@babel/types" "^7.18.9"
+
 "@babel/helper-optimise-call-expression@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz#cecdb145d70c54096b1564f8e9f10cd7d193b338"
@@ -204,22 +240,22 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
-"@babel/helper-optimise-call-expression@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz#a34e3560605abbd31a18546bd2aad3e6d9a174f2"
-  integrity sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==
+"@babel/helper-optimise-call-expression@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz#9369aa943ee7da47edab2cb4e838acf09d290ffe"
+  integrity sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==
   dependencies:
-    "@babel/types" "^7.16.7"
+    "@babel/types" "^7.18.6"
 
-"@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.8.0":
+"@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz#4b8aea3b069d8cb8a72cdfe28ddf5ceca695ef2f"
+  integrity sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==
+
+"@babel/helper-plugin-utils@^7.8.0":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
   integrity sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
-
-"@babel/helper-plugin-utils@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz#aa3a8ab4c3cceff8e65eb9e73d87dc4ff320b2f5"
-  integrity sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==
 
 "@babel/helper-replace-supers@^7.16.0":
   version "7.16.0"
@@ -231,16 +267,16 @@
     "@babel/traverse" "^7.16.0"
     "@babel/types" "^7.16.0"
 
-"@babel/helper-replace-supers@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.16.7.tgz#e9f5f5f32ac90429c1a4bdec0f231ef0c2838ab1"
-  integrity sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==
+"@babel/helper-replace-supers@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.18.9.tgz#1092e002feca980fbbb0bd4d51b74a65c6a500e6"
+  integrity sha512-dNsWibVI4lNT6HiuOIBr1oyxo40HvIVmbwPUm3XZ7wMh4k2WxrxTqZwSqw/eEmXDS9np0ey5M2bz9tBmO9c+YQ==
   dependencies:
-    "@babel/helper-environment-visitor" "^7.16.7"
-    "@babel/helper-member-expression-to-functions" "^7.16.7"
-    "@babel/helper-optimise-call-expression" "^7.16.7"
-    "@babel/traverse" "^7.16.7"
-    "@babel/types" "^7.16.7"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-member-expression-to-functions" "^7.18.9"
+    "@babel/helper-optimise-call-expression" "^7.18.6"
+    "@babel/traverse" "^7.18.9"
+    "@babel/types" "^7.18.9"
 
 "@babel/helper-simple-access@^7.16.0":
   version "7.16.0"
@@ -249,6 +285,13 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
+"@babel/helper-simple-access@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz#d6d8f51f4ac2978068df934b569f08f29788c7ea"
+  integrity sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==
+  dependencies:
+    "@babel/types" "^7.18.6"
+
 "@babel/helper-split-export-declaration@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz#29672f43663e936df370aaeb22beddb3baec7438"
@@ -256,32 +299,37 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
-"@babel/helper-split-export-declaration@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz#0b648c0c42da9d3920d85ad585f2778620b8726b"
-  integrity sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==
+"@babel/helper-split-export-declaration@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz#7367949bc75b20c6d5a5d4a97bba2824ae8ef075"
+  integrity sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==
   dependencies:
-    "@babel/types" "^7.16.7"
+    "@babel/types" "^7.18.6"
+
+"@babel/helper-string-parser@^7.18.10":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz#181f22d28ebe1b3857fa575f5c290b1aaf659b56"
+  integrity sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==
 
 "@babel/helper-validator-identifier@^7.15.7":
   version "7.15.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
   integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
 
-"@babel/helper-validator-identifier@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
-  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+"@babel/helper-validator-identifier@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
+  integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
 
 "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
   integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
 
-"@babel/helper-validator-option@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz#b203ce62ce5fe153899b617c08957de860de4d23"
-  integrity sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==
+"@babel/helper-validator-option@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz#bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8"
+  integrity sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==
 
 "@babel/helpers@^7.16.0":
   version "7.16.3"
@@ -292,6 +340,15 @@
     "@babel/traverse" "^7.16.3"
     "@babel/types" "^7.16.0"
 
+"@babel/helpers@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.18.9.tgz#4bef3b893f253a1eced04516824ede94dcfe7ff9"
+  integrity sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==
+  dependencies:
+    "@babel/template" "^7.18.6"
+    "@babel/traverse" "^7.18.9"
+    "@babel/types" "^7.18.9"
+
 "@babel/highlight@^7.16.0":
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.0.tgz#6ceb32b2ca4b8f5f361fb7fd821e3fddf4a1725a"
@@ -301,12 +358,12 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/highlight@^7.16.7":
-  version "7.16.10"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.16.10.tgz#744f2eb81579d6eea753c227b0f570ad785aba88"
-  integrity sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
+"@babel/highlight@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
+  integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.16.7"
+    "@babel/helper-validator-identifier" "^7.18.6"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -315,36 +372,36 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.16.4.tgz#d5f92f57cf2c74ffe9b37981c0e72fee7311372e"
   integrity sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==
 
-"@babel/parser@^7.16.7", "@babel/parser@^7.17.3":
-  version "7.17.8"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.8.tgz#2817fb9d885dd8132ea0f8eb615a6388cca1c240"
-  integrity sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==
+"@babel/parser@^7.18.10", "@babel/parser@^7.18.13":
+  version "7.18.13"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.13.tgz#5b2dd21cae4a2c5145f1fbd8ca103f9313d3b7e4"
+  integrity sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==
 
-"@babel/plugin-proposal-class-properties@~7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.0.tgz#c029618267ddebc7280fa286e0f8ca2a278a2d1a"
-  integrity sha512-mCF3HcuZSY9Fcx56Lbn+CGdT44ioBMMvjNVldpKtj8tpniETdLjnxdHI1+sDWXIM1nNt+EanJOZ3IG9lzVjs7A==
+"@babel/plugin-proposal-class-properties@~7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz#b110f59741895f7ec21a6fff696ec46265c446a3"
+  integrity sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.16.0"
-    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/helper-create-class-features-plugin" "^7.18.6"
+    "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-proposal-object-rest-spread@~7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.16.0.tgz#5fb32f6d924d6e6712810362a60e12a2609872e6"
-  integrity sha512-LU/+jp89efe5HuWJLmMmFG0+xbz+I2rSI7iLc1AlaeSMDMOGzWlc5yJrMN1d04osXN4sSfpo4O+azkBNBes0jg==
+"@babel/plugin-proposal-object-rest-spread@~7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.18.9.tgz#f9434f6beb2c8cae9dfcf97d2a5941bbbf9ad4e7"
+  integrity sha512-kDDHQ5rflIeY5xl69CEqGEZ0KY369ehsCIEbTGb4siHG5BE9sga/T0r0OUwyZNLMmZE79E1kbsqAjwFCW4ds6Q==
   dependencies:
-    "@babel/compat-data" "^7.16.0"
-    "@babel/helper-compilation-targets" "^7.16.0"
-    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/compat-data" "^7.18.8"
+    "@babel/helper-compilation-targets" "^7.18.9"
+    "@babel/helper-plugin-utils" "^7.18.9"
     "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
-    "@babel/plugin-transform-parameters" "^7.16.0"
+    "@babel/plugin-transform-parameters" "^7.18.8"
 
-"@babel/plugin-syntax-decorators@^7.17.0":
-  version "7.17.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.17.0.tgz#a2be3b2c9fe7d78bd4994e790896bc411e2f166d"
-  integrity sha512-qWe85yCXsvDEluNP0OyeQjH63DlhAR3W7K9BxxU1MvbDb48tgBG+Ao6IJJ6smPDrrVzSQZrbF6donpkFBMcs3A==
+"@babel/plugin-syntax-decorators@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.18.6.tgz#2e45af22835d0b0f8665da2bfd4463649ce5dbc1"
+  integrity sha512-fqyLgjcxf/1yhyZ6A+yo1u9gJ7eleFQod2lkaUsF9DQ7sbbY3Ligym3L0+I2c0WmqNKDpoD9UTb1AKP3qRMOAQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.18.6"
 
 "@babel/plugin-syntax-object-rest-spread@^7.8.3":
   version "7.8.3"
@@ -353,37 +410,37 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-typescript@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.7.tgz#39c9b55ee153151990fb038651d58d3fd03f98f8"
-  integrity sha512-YhUIJHHGkqPgEcMYkPCKTyGUdoGKWtopIycQyjJH8OjvRgOYsXsaKehLVPScKJWAULPxMa4N1vCe6szREFlZ7A==
+"@babel/plugin-syntax-typescript@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.18.6.tgz#1c09cd25795c7c2b8a4ba9ae49394576d4133285"
+  integrity sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-transform-parameters@^7.16.0":
-  version "7.16.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.3.tgz#fa9e4c874ee5223f891ee6fa8d737f4766d31d15"
-  integrity sha512-3MaDpJrOXT1MZ/WCmkOFo7EtmVVC8H4EUZVrHvFOsmwkk4lOjQj8rzv8JKUZV4YoQKeoIgk07GO+acPU9IMu/w==
+"@babel/plugin-transform-parameters@^7.18.8":
+  version "7.18.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.18.8.tgz#ee9f1a0ce6d78af58d0956a9378ea3427cccb48a"
+  integrity sha512-ivfbE3X2Ss+Fj8nnXvKJS6sjRG4gzwPMsP+taZC+ZzEGjAYlvENixmt1sZ5Ca6tWls+BlKSGKPJ6OOXvXCbkFg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-transform-typescript@^7.16.7":
-  version "7.16.8"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.8.tgz#591ce9b6b83504903fa9dd3652c357c2ba7a1ee0"
-  integrity sha512-bHdQ9k7YpBDO2d0NVfkj51DpQcvwIzIusJ7mEUaMlbZq3Kt/U47j24inXZHQ5MDiYpCs+oZiwnXyKedE8+q7AQ==
+"@babel/plugin-transform-typescript@^7.18.6":
+  version "7.18.12"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.12.tgz#712e9a71b9e00fde9f8c0238e0cceee86ab2f8fd"
+  integrity sha512-2vjjam0cum0miPkenUbQswKowuxs/NjMwIKEq0zwegRxXk12C9YOF9STXnaUptITOtOJHKHpzvvWYOjbm6tc0w==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.16.7"
-    "@babel/helper-plugin-utils" "^7.16.7"
-    "@babel/plugin-syntax-typescript" "^7.16.7"
+    "@babel/helper-create-class-features-plugin" "^7.18.9"
+    "@babel/helper-plugin-utils" "^7.18.9"
+    "@babel/plugin-syntax-typescript" "^7.18.6"
 
-"@babel/preset-typescript@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.16.7.tgz#ab114d68bb2020afc069cd51b37ff98a046a70b9"
-  integrity sha512-WbVEmgXdIyvzB77AQjGBEyYPZx+8tTsO50XtfozQrkW8QB2rLJpH2lgx0TRw5EJrBxOZQ+wCcyPVQvS8tjEHpQ==
+"@babel/preset-typescript@^7.18.6":
+  version "7.18.6"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.18.6.tgz#ce64be3e63eddc44240c6358daefac17b3186399"
+  integrity sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.16.7"
-    "@babel/helper-validator-option" "^7.16.7"
-    "@babel/plugin-transform-typescript" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.18.6"
+    "@babel/helper-validator-option" "^7.18.6"
+    "@babel/plugin-transform-typescript" "^7.18.6"
 
 "@babel/template@^7.16.0":
   version "7.16.0"
@@ -394,14 +451,14 @@
     "@babel/parser" "^7.16.0"
     "@babel/types" "^7.16.0"
 
-"@babel/template@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
-  integrity sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==
+"@babel/template@^7.18.10", "@babel/template@^7.18.6":
+  version "7.18.10"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.18.10.tgz#6f9134835970d1dbf0835c0d100c9f38de0c5e71"
+  integrity sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==
   dependencies:
-    "@babel/code-frame" "^7.16.7"
-    "@babel/parser" "^7.16.7"
-    "@babel/types" "^7.16.7"
+    "@babel/code-frame" "^7.18.6"
+    "@babel/parser" "^7.18.10"
+    "@babel/types" "^7.18.10"
 
 "@babel/traverse@^7.16.0", "@babel/traverse@^7.16.3":
   version "7.16.3"
@@ -418,19 +475,19 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/traverse@^7.16.7":
-  version "7.17.3"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.17.3.tgz#0ae0f15b27d9a92ba1f2263358ea7c4e7db47b57"
-  integrity sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==
+"@babel/traverse@^7.18.13", "@babel/traverse@^7.18.9":
+  version "7.18.13"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.13.tgz#5ab59ef51a997b3f10c4587d648b9696b6cb1a68"
+  integrity sha512-N6kt9X1jRMLPxxxPYWi7tgvJRH/rtoU+dbKAPDM44RFHiMH8igdsaSBgFeskhSl/kLWLDUvIh1RXCrTmg0/zvA==
   dependencies:
-    "@babel/code-frame" "^7.16.7"
-    "@babel/generator" "^7.17.3"
-    "@babel/helper-environment-visitor" "^7.16.7"
-    "@babel/helper-function-name" "^7.16.7"
-    "@babel/helper-hoist-variables" "^7.16.7"
-    "@babel/helper-split-export-declaration" "^7.16.7"
-    "@babel/parser" "^7.17.3"
-    "@babel/types" "^7.17.0"
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.18.13"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.18.9"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.18.13"
+    "@babel/types" "^7.18.13"
     debug "^4.1.0"
     globals "^11.1.0"
 
@@ -442,12 +499,13 @@
     "@babel/helper-validator-identifier" "^7.15.7"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.16.7", "@babel/types@^7.17.0":
-  version "7.17.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
-  integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
+"@babel/types@^7.18.10", "@babel/types@^7.18.13", "@babel/types@^7.18.6", "@babel/types@^7.18.9":
+  version "7.18.13"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.13.tgz#30aeb9e514f4100f7c1cb6e5ba472b30e48f519a"
+  integrity sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.16.7"
+    "@babel/helper-string-parser" "^7.18.10"
+    "@babel/helper-validator-identifier" "^7.18.6"
     to-fast-properties "^2.0.0"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
@@ -466,7 +524,15 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jridgewell/gen-mapping@^0.3.0":
+"@jridgewell/gen-mapping@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
+  integrity sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==
+  dependencies:
+    "@jridgewell/set-array" "^1.0.0"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/gen-mapping@^0.3.0", "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
   integrity sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==
@@ -480,7 +546,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
 
-"@jridgewell/set-array@^1.0.1":
+"@jridgewell/set-array@^1.0.0", "@jridgewell/set-array@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
@@ -506,97 +572,97 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@lwc/babel-plugin-component@2.5.10":
-  version "2.5.10"
-  resolved "https://registry.yarnpkg.com/@lwc/babel-plugin-component/-/babel-plugin-component-2.5.10.tgz#292209db03f41c20ff67649ddaed6bf56abbe9fe"
-  integrity sha512-vvUDpiTHNuhkhzMNohBT+ZVEbrfpTDn0yRZA9Bd+FKVUhpJPUFJdau7jtX9KmIEVOoI4oN5r8Ba7lyBMauk3NQ==
+"@lwc/babel-plugin-component@2.23.2":
+  version "2.23.2"
+  resolved "https://registry.yarnpkg.com/@lwc/babel-plugin-component/-/babel-plugin-component-2.23.2.tgz#ade3fe39370fddd0698e67df8d33037a40ee8ea3"
+  integrity sha512-hO5PKvq8jD5uYHDnOBnRhwNDHlPtUEXVL4VN8eGfXQJNue51mrLwQGCACs5Mme+X2aY302nsyGFiZMuS5Y28Tw==
   dependencies:
-    "@babel/helper-module-imports" "~7.16.0"
-    "@lwc/errors" "2.5.10"
+    "@babel/helper-module-imports" "~7.18.6"
+    "@lwc/errors" "2.23.2"
+    "@lwc/shared" "2.23.2"
     line-column "~1.0.2"
 
-"@lwc/compiler@2.5.10":
-  version "2.5.10"
-  resolved "https://registry.yarnpkg.com/@lwc/compiler/-/compiler-2.5.10.tgz#a890510be0a52fda5065437974c595dfe3c9ba7e"
-  integrity sha512-eSJREdvRJJGg60THP4nMs+87hr94Oo/sCvmJ2KCGKjofF+rJQTOyi1Sgh6oKrq58EFJUffSINCbEyWREZoTlCA==
+"@lwc/compiler@2.23.2":
+  version "2.23.2"
+  resolved "https://registry.yarnpkg.com/@lwc/compiler/-/compiler-2.23.2.tgz#458592b591ce51d27e5addd3d3f7721148045035"
+  integrity sha512-Myj24zhdgJZ6mM95/qEZFkV5Qv2P5Ujd7EKlOmCg1WLmY29O2hHkzrtlLz3+xPo3JmYtCbvbGxsDU1Gr/fL4Cw==
   dependencies:
-    "@babel/core" "~7.16.0"
-    "@babel/plugin-proposal-class-properties" "~7.16.0"
-    "@babel/plugin-proposal-object-rest-spread" "~7.16.0"
-    "@lwc/babel-plugin-component" "2.5.10"
-    "@lwc/errors" "2.5.10"
-    "@lwc/shared" "2.5.10"
-    "@lwc/style-compiler" "2.5.10"
-    "@lwc/template-compiler" "2.5.10"
+    "@babel/core" "~7.18.13"
+    "@babel/plugin-proposal-class-properties" "~7.18.6"
+    "@babel/plugin-proposal-object-rest-spread" "~7.18.9"
+    "@lwc/babel-plugin-component" "2.23.2"
+    "@lwc/errors" "2.23.2"
+    "@lwc/shared" "2.23.2"
+    "@lwc/style-compiler" "2.23.2"
+    "@lwc/template-compiler" "2.23.2"
 
-"@lwc/engine-dom@2.5.10":
-  version "2.5.10"
-  resolved "https://registry.yarnpkg.com/@lwc/engine-dom/-/engine-dom-2.5.10.tgz#f4c221d0ca4ae1225d7ee4daf577fb243d7fdd4d"
-  integrity sha512-w+iZf6uGeYPv7hMuYm2jCwP6zon+7oJYtHvDX+k4bGv/ZJvkl5GN63uqZYEGDEIs6BaR4YUVbKTdUk8L27YV6Q==
+"@lwc/engine-dom@2.23.2":
+  version "2.23.2"
+  resolved "https://registry.yarnpkg.com/@lwc/engine-dom/-/engine-dom-2.23.2.tgz#16442f88ec6de12ea390fd59e6fe01486b554c37"
+  integrity sha512-XEfn3boHv7RLWevOMwKawxFCrs9btbvyi5XaFsclwkrqEBZa+k5px5vyYEsCJozrvz2ddHkhcuZpG7jITPwNKQ==
 
-"@lwc/engine-server@2.5.10":
-  version "2.5.10"
-  resolved "https://registry.yarnpkg.com/@lwc/engine-server/-/engine-server-2.5.10.tgz#a5a0ceebfe445a396d2f7259712331cb302a5edd"
-  integrity sha512-qzYtv5FoFSVijCMpfyMAJ/b3ODJF3ezXKQkX7oLVicpUYlfUg0+GZRzgHafI7cz/mdiznoICtnu6YkaXxFSbHQ==
+"@lwc/engine-server@2.23.2":
+  version "2.23.2"
+  resolved "https://registry.yarnpkg.com/@lwc/engine-server/-/engine-server-2.23.2.tgz#d295530a66aa993ed99421a15cdfbb73eb905c69"
+  integrity sha512-Pc3e2WpGEsUhne9ZSX3DpWNz/AU83QSBOAbIBzLGF8WOzRfV50X+werEqmbWtw+tNCY6IVf/05QD95CYxiqN5A==
 
-"@lwc/errors@2.5.10":
-  version "2.5.10"
-  resolved "https://registry.yarnpkg.com/@lwc/errors/-/errors-2.5.10.tgz#549a1790115415658298fc002169eebfaf082386"
-  integrity sha512-CgSFVyP/PZr42a1gmReN5GJAf1AMeSgAVlCUhuf0XY8LiduQPvmBqUHOsgdFkADcDp1sfwcWKp6wfB+WIU+sYQ==
+"@lwc/errors@2.23.2":
+  version "2.23.2"
+  resolved "https://registry.yarnpkg.com/@lwc/errors/-/errors-2.23.2.tgz#e96f677a8dccbeb57ff339a6a58ea815018ec8bc"
+  integrity sha512-rgqdd6aQja4T8ysmt2L1o9Aq+VWCtifcJv1FB/hNs1g2KloxZyZkHtK6Y+Tr4IXdgiH5LaT0L3tiQA3X4vssoQ==
 
-"@lwc/features@2.5.10":
-  version "2.5.10"
-  resolved "https://registry.yarnpkg.com/@lwc/features/-/features-2.5.10.tgz#a3fa92426b666afa60f0ca95c5d248106bd6fc0f"
-  integrity sha512-e7Dr9wuqS6QPb2bMfxXIT3kPRM/S78QpD2QEdo+7Bhu8hFDECU3JwGaeS6zoZVcsJ0eORdxqUvihiTE8FABVzQ==
+"@lwc/features@2.23.2":
+  version "2.23.2"
+  resolved "https://registry.yarnpkg.com/@lwc/features/-/features-2.23.2.tgz#dcb47abe1042652b74ac6d034cf6903764313ffe"
+  integrity sha512-ibETXHprrDfo0xw8lutpAhHTSOmTL1ymtNLiIwEbUk9YxQE2mfyUr22XmwlD1rc5FKO4zqcgK1NG1T7nKv/ooQ==
   dependencies:
-    "@lwc/shared" "2.5.10"
+    "@lwc/shared" "2.23.2"
 
-"@lwc/module-resolver@2.5.10":
-  version "2.5.10"
-  resolved "https://registry.yarnpkg.com/@lwc/module-resolver/-/module-resolver-2.5.10.tgz#32597291d0486f189cc234b122c070fd7a35b91e"
-  integrity sha512-h7u71Rut1hQOPzhi+Hp8bagzBzTQsMIPNmyMHgR7M+BdAV68Jv0VKFgbjIHZOXy6N53jOgxandR7oM8mpUA4WA==
+"@lwc/module-resolver@2.23.2":
+  version "2.23.2"
+  resolved "https://registry.yarnpkg.com/@lwc/module-resolver/-/module-resolver-2.23.2.tgz#129d10c725bb3179e18abf7de2d9c3af0bdc1719"
+  integrity sha512-/0EGjzHIgEBu6Ot+wZpb3pzyP/qLIyCVGKQq0D1alFnBo3dCFVGMA1w0gCGRNn0TElq8fMukUcjr7ST7F/laUg==
   dependencies:
-    resolve "~1.20.0"
+    resolve "~1.22.1"
 
-"@lwc/shared@2.5.10":
-  version "2.5.10"
-  resolved "https://registry.yarnpkg.com/@lwc/shared/-/shared-2.5.10.tgz#b9074431076abd6fb0a1e0557007a262d6521bd7"
-  integrity sha512-77KmrIXeGIMjRgQQq0qBFXsssfoxjR8C43esKHcZV4SSMJT/cKZSCYaudbtJquJPqfENadcLyoDz6OeAWpzueA==
+"@lwc/shared@2.23.2":
+  version "2.23.2"
+  resolved "https://registry.yarnpkg.com/@lwc/shared/-/shared-2.23.2.tgz#8aba761dbce8b626e5bd1a41d0f894cbf80ceca5"
+  integrity sha512-LgPs0RTaNRs382/+G1UpDDfh4F4NDiXhIFvUOJhtastciBJndXKdEN27aFdAVxrs+yCt9fCM5wgKVhyZSiGBrQ==
 
-"@lwc/style-compiler@2.5.10":
-  version "2.5.10"
-  resolved "https://registry.yarnpkg.com/@lwc/style-compiler/-/style-compiler-2.5.10.tgz#b954faad183c9531ba1f3d214542c5acbdfb16dd"
-  integrity sha512-vQc1l95NHcit5kQzR93Dvy4QRHJCfyr5NI2D+j6J1nlut+edqYgh06nJererIsXtNtsxUUgStpq8MkR83PoaEg==
+"@lwc/style-compiler@2.23.2":
+  version "2.23.2"
+  resolved "https://registry.yarnpkg.com/@lwc/style-compiler/-/style-compiler-2.23.2.tgz#a93525b715b27390ee2fdc7e45a1901b0fc5426d"
+  integrity sha512-cNKn18CRzv1IXDQ+tboUGB/VU8ubmnZ3kpGDyPk1VBUWaUdU9HhSXsl+4z/l8UdvNEEYnR3XqQYVsEnpMFO20w==
   dependencies:
-    "@lwc/shared" "2.5.10"
-    postcss "~8.3.11"
-    postcss-selector-parser "~6.0.4"
-    postcss-value-parser "~4.1.0"
-    string.prototype.matchall "^4.0.5"
+    "@lwc/shared" "2.23.2"
+    postcss "~8.4.16"
+    postcss-selector-parser "~6.0.9"
+    postcss-value-parser "~4.2.0"
+    string.prototype.matchall "^4.0.7"
 
-"@lwc/synthetic-shadow@2.5.10":
-  version "2.5.10"
-  resolved "https://registry.yarnpkg.com/@lwc/synthetic-shadow/-/synthetic-shadow-2.5.10.tgz#fe7e5d92570817bd0d6ef8ac523daa919ac12204"
-  integrity sha512-NHX5/qCtRr3OPpEt48PgelySKtV6JWRSbwNaAZOs0NAhgCLRIG5JnxtztQLHsBDhVtxYW2L0d5rfxQuvt9aO1A==
+"@lwc/synthetic-shadow@2.23.2":
+  version "2.23.2"
+  resolved "https://registry.yarnpkg.com/@lwc/synthetic-shadow/-/synthetic-shadow-2.23.2.tgz#ac0f0b12a892d740d9ee2d4156c8bbcdcbb9d4d8"
+  integrity sha512-AJk5PFvNtNWHaVVQ4ePlr8+301SmekSF5fd+MifvT3p8sgNCmE7ZlCIsUkgD2qLu/xXLum4451BWBMPgC75r1Q==
 
-"@lwc/template-compiler@2.5.10":
-  version "2.5.10"
-  resolved "https://registry.yarnpkg.com/@lwc/template-compiler/-/template-compiler-2.5.10.tgz#fde14a50243938080c40bc74d33399f79881aa03"
-  integrity sha512-TCY3Z7/dxzfSy1ECMorKrTGk36mUWNN7O6F0j5LU8IYTWffJPyGyOsTDnXTl/hogu/7Nr9sMKy8XbpgSixpfjg==
+"@lwc/template-compiler@2.23.2":
+  version "2.23.2"
+  resolved "https://registry.yarnpkg.com/@lwc/template-compiler/-/template-compiler-2.23.2.tgz#3a5039e4d57a65f41a391c53ceaa887f97df051d"
+  integrity sha512-on6kRYprRfgKxXUDZNBjvLqp5WFQAOV6HTBx6PqW5j0s18Bz0qlF5w2VAv/2ZSfUtzK9544OC3wku4LZP43B2g==
   dependencies:
-    "@lwc/errors" "2.5.10"
-    "@lwc/shared" "2.5.10"
-    acorn "~8.5.0"
-    astring "~1.7.0"
+    "@lwc/errors" "2.23.2"
+    "@lwc/shared" "2.23.2"
+    acorn "~8.8.0"
+    astring "~1.8.3"
     estree-walker "~2.0.2"
-    esutils "~2.0.3"
     he "~1.2.0"
     parse5 "~6.0.1"
 
-"@lwc/wire-service@2.5.10":
-  version "2.5.10"
-  resolved "https://registry.yarnpkg.com/@lwc/wire-service/-/wire-service-2.5.10.tgz#fffc0338f0078c749b3637aa5150004652689e23"
-  integrity sha512-BypuyqDoqkt+FcCrJi59FbVmw46/G3lXluPpkBz8vvlXnvV+7UDdtx0+QBQfFZjC/CSLpVOR+6jM3wtvWtCTbQ==
+"@lwc/wire-service@2.23.2":
+  version "2.23.2"
+  resolved "https://registry.yarnpkg.com/@lwc/wire-service/-/wire-service-2.23.2.tgz#5a0c0de9e0647106a4284a7a311582c9954f8d93"
+  integrity sha512-by+Uo6mseygZUUv7fdlcjU8FwsXKPvfZOMEf1PXP/iYdhSYAechV4LnrAYgGoGwduRr97860PBw6tp2Bb74FQw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -660,10 +726,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.10.tgz#2e3ad0a680d96367103d3e670d41c2fed3da61ae"
   integrity sha512-3aRnHa1KlOEEhJ6+CvyHKK5vE9BcLGjtUpwvqYLRvYNQKMfabu3BwfJaA/SLW8dxe28LsNDjtHwePTuzn3gmOA==
 
-"@types/node@~16.11.26":
-  version "16.11.26"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.26.tgz#63d204d136c9916fb4dcd1b50f9740fe86884e47"
-  integrity sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==
+"@types/node@~18.7.14":
+  version "18.7.14"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.14.tgz#0fe081752a3333392d00586d815485a17c2cf3c9"
+  integrity sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==
 
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
@@ -806,15 +872,15 @@ acorn-import-assertions@^1.7.6:
   resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz#ba2b5939ce62c238db6d93d81c9b111b29b855e9"
   integrity sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==
 
-acorn@^8.4.1, acorn@^8.5.0:
+acorn@^8.5.0:
   version "8.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
   integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
 
-acorn@~8.5.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
-  integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
+acorn@^8.7.1, acorn@~8.8.0:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
+  integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -900,15 +966,15 @@ assertion-error@^1.1.0:
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
   integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
-astring@~1.7.0:
-  version "1.7.6"
-  resolved "https://registry.yarnpkg.com/astring/-/astring-1.7.6.tgz#3e1c34b2ad22f358d827c2a43f94ceaa785b3876"
-  integrity sha512-7ofuRb7zx2u7T4OGZTtfkGKAfPKq72XQ7zgpI2b3pR3wdROrDIDmKPtrel7D8S4t+97SGpYTpDR6lq5cNX/DJw==
+astring@~1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/astring/-/astring-1.8.3.tgz#1a0ae738c7cc558f8e5ddc8e3120636f5cebcb85"
+  integrity sha512-sRpyiNrx2dEYIMmUXprS8nlpRg2Drs8m9ElX9vVEXaCB4XEAJhKfs7IcX0IwShjuOAjLR6wzIrgoptz1n19i1A==
 
-babel-loader@^8.2.4:
-  version "8.2.4"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.2.4.tgz#95f5023c791b2e9e2ca6f67b0984f39c82ff384b"
-  integrity sha512-8dytA3gcvPPPv4Grjhnt8b5IIiTcq/zeXOPk4iTYI0SVXcsmuGg7JtBRDp8S9X+gJfhQ8ektjXZlDu1Bb33U8A==
+babel-loader@^8.2.5:
+  version "8.2.5"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.2.5.tgz#d45f585e654d5a5d90f5350a779d7647c5ed512e"
+  integrity sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==
   dependencies:
     find-cache-dir "^3.3.1"
     loader-utils "^2.0.0"
@@ -938,6 +1004,13 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
@@ -960,6 +1033,16 @@ browserslist@^4.14.5, browserslist@^4.17.5:
     escalade "^3.1.1"
     node-releases "^2.0.1"
     picocolors "^1.0.0"
+
+browserslist@^4.20.2:
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.3.tgz#5df277694eb3c48bc5c4b05af3e8b7e09c5a6d1a"
+  integrity sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==
+  dependencies:
+    caniuse-lite "^1.0.30001370"
+    electron-to-chromium "^1.4.202"
+    node-releases "^2.0.6"
+    update-browserslist-db "^1.0.5"
 
 buffer-from@^1.0.0:
   version "1.1.2"
@@ -998,6 +1081,11 @@ caniuse-lite@^1.0.30001280:
   version "1.0.30001282"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz#38c781ee0a90ccfe1fe7fefd00e43f5ffdcb96fd"
   integrity sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==
+
+caniuse-lite@^1.0.30001370:
+  version "1.0.30001387"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001387.tgz#90d2b9bdfcc3ab9a5b9addee00a25ef86c9e2e1e"
+  integrity sha512-fKDH0F1KOJvR+mWSOvhj8lVRr/Q/mc5u5nabU2vi1/sgvlSqEsE8dOq0Hy/BqVbDkCYQPRRHB1WRjW6PGB/7PA==
 
 chai@^4.3.6:
   version "4.3.6"
@@ -1146,10 +1234,10 @@ cssesc@^3.0.0:
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
-debug@4.3.3:
-  version "4.3.3"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
-  integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+debug@4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
@@ -1201,6 +1289,11 @@ electron-to-chromium@^1.3.896:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.0.tgz#7456192519838f881e35e4038bf4ad2c36353e63"
   integrity sha512-+oXCt6SaIu8EmFTPx8wNGSB0tHQ5biDscnlf6Uxuz17e9CjzMRtGk9B8705aMPnj0iWr3iC74WuIkngCsLElmA==
 
+electron-to-chromium@^1.4.202:
+  version "1.4.237"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.237.tgz#c695c5fedc3bb48f04ba1b39470c5aef2aaafd84"
+  integrity sha512-vxVyGJcsgArNOVUJcXm+7iY3PJAfmSapEszQD1HbyPLl0qoCmNQ1o/EX3RI7Et5/88In9oLxX3SGF8J3orkUgA==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -1211,10 +1304,10 @@ emojis-list@^3.0.0:
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
 
-enhanced-resolve@^5.8.3:
-  version "5.9.1"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.9.1.tgz#e898cea44d9199fd92137496cff5691b910fb43e"
-  integrity sha512-jdyZMwCQ5Oj4c5+BTnkxPgDZO/BJzh/ADDmKebayyzNwjVX1AFCeGkOfxNx0mHi2+8BKC5VxUYiw3TIvoT7vhw==
+enhanced-resolve@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz#0dc579c3bb2a1032e357ac45b8f3a6f3ad4fb1e6"
+  integrity sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -1314,11 +1407,6 @@ estree-walker@~2.0.2:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
-esutils@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
-  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
-
 events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
@@ -1402,7 +1490,7 @@ fromentries@^1.2.0:
   resolved "https://registry.yarnpkg.com/fromentries/-/fromentries-1.3.2.tgz#e4bca6808816bf8f93b52750f1127f5a6fd86e3a"
   integrity sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==
 
-fs-monkey@1.0.3:
+fs-monkey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.3.tgz#ae3ac92d53bb328efe0e9a1d9541f6ad8d48e2d3"
   integrity sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==
@@ -1421,6 +1509,11 @@ function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
+functions-have-names@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
+  integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -1498,11 +1591,6 @@ graceful-fs@^4.2.9:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
   integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
 
-growl@1.10.5:
-  version "1.10.5"
-  resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
-  integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
-
 has-bigints@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
@@ -1522,6 +1610,11 @@ has-symbols@^1.0.1, has-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-symbols@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
 has-tostringtag@^1.0.0:
   version "1.0.0"
@@ -1614,10 +1707,10 @@ is-callable@^1.1.4, is-callable@^1.2.4:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
   integrity sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==
 
-is-core-module@^2.2.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.0.tgz#0321336c3d0925e497fd97f5d95cb114a5ccd548"
-  integrity sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==
+is-core-module@^2.9.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.10.0.tgz#9012ede0a91c69587e647514e1d5277019e728ed"
+  integrity sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==
   dependencies:
     has "^1.0.3"
 
@@ -1845,22 +1938,15 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
-json-parse-better-errors@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
-  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
+json-parse-even-better-errors@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz#7c47805a94319928e05777405dc12e1f7a4ee02d"
+  integrity sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
-
-json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
-  dependencies:
-    minimist "^1.2.0"
 
 json5@^2.1.2:
   version "2.2.0"
@@ -1868,6 +1954,11 @@ json5@^2.1.2:
   integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   dependencies:
     minimist "^1.2.5"
+
+json5@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.1.tgz#655d50ed1e6f95ad1a3caababd2b0efda10b395c"
+  integrity sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==
 
 kind-of@^6.0.2:
   version "6.0.3"
@@ -1886,15 +1977,6 @@ loader-runner@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.2.0.tgz#d7022380d66d14c5fb1d496b89864ebcfd478384"
   integrity sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==
-
-loader-utils@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
-  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^3.0.0"
-    json5 "^1.0.1"
 
 loader-utils@^2.0.0:
   version "2.0.2"
@@ -1939,17 +2021,17 @@ loupe@^2.3.1:
   dependencies:
     get-func-name "^2.0.0"
 
-lwc@2.5.10:
-  version "2.5.10"
-  resolved "https://registry.yarnpkg.com/lwc/-/lwc-2.5.10.tgz#b4e67bf0c7689e4140ec00734e3a8efe3c8f684f"
-  integrity sha512-m3IcjBGGOApPCNV7Rw2dtmCkY/u4D0lyQhuh5JgJCq9CWYnVFWWOnmCGRf7yfXCc4dmRyYVuzqCJIlk2pWtrMA==
+lwc@2.23.2:
+  version "2.23.2"
+  resolved "https://registry.yarnpkg.com/lwc/-/lwc-2.23.2.tgz#26385fccb01422c9d82e612e9126b9c96509ab1e"
+  integrity sha512-EWk35X84oLelZ0CzHO28pz1Y/ymU9dsHk4n4Chzgx78F50DfayzHKcdW2VY69CsHmUWe1IxeM9c5E/0QsTx5uw==
   dependencies:
-    "@lwc/compiler" "2.5.10"
-    "@lwc/engine-dom" "2.5.10"
-    "@lwc/engine-server" "2.5.10"
-    "@lwc/features" "2.5.10"
-    "@lwc/synthetic-shadow" "2.5.10"
-    "@lwc/wire-service" "2.5.10"
+    "@lwc/compiler" "2.23.2"
+    "@lwc/engine-dom" "2.23.2"
+    "@lwc/engine-server" "2.23.2"
+    "@lwc/features" "2.23.2"
+    "@lwc/synthetic-shadow" "2.23.2"
+    "@lwc/wire-service" "2.23.2"
 
 make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   version "3.1.0"
@@ -1958,12 +2040,12 @@ make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   dependencies:
     semver "^6.0.0"
 
-memfs@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.4.1.tgz#b78092f466a0dce054d63d39275b24c71d3f1305"
-  integrity sha512-1c9VPVvW5P7I85c35zAdEr1TD5+F11IToIHIlrVIcflfnzPkJa0ZoYEoEdYDP8KgPFoSZ/opDrUsAoZWym3mtw==
+memfs@^3.4.7:
+  version "3.4.7"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.4.7.tgz#e5252ad2242a724f938cb937e3c4f7ceb1f70e5a"
+  integrity sha512-ygaiUSNalBX85388uskeCyhSAoOSgzBbtVCr9jA2RROssFL9Q19/ZXFqS+2Th2sr1ewNIWgFdLzLC3Yl1Zv+lw==
   dependencies:
-    fs-monkey "1.0.3"
+    fs-monkey "^1.0.3"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -1995,51 +2077,56 @@ mime-types@^2.1.27:
   dependencies:
     mime-db "1.51.0"
 
-minimatch@3.0.4, minimatch@^3.0.4:
+minimatch@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.0.1.tgz#fb9022f7528125187c92bd9e9b6366be1cf3415b"
+  integrity sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
-mocha-snap@^4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/mocha-snap/-/mocha-snap-4.2.4.tgz#64d3307636ec9daa37a48b08db4ddbb99d26f13a"
-  integrity sha512-whmmGIM6lE9Enf8Y5S4cJQD6hrwWfM/x3MD14sBgf9LQEoatkJbbb2yi5UUPNu1PnFEi97hOnuc7ydi8BxbiwQ==
+mocha-snap@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/mocha-snap/-/mocha-snap-4.3.0.tgz#cf9892fd28d2c0775495a1d5bebf812138013fc6"
+  integrity sha512-Z41NHLFeW7ZmOEmGzn+hnpPaRxQvGMgpXkx9zV1QbPlskyWzHN74AyWVRWTler30VGFUS60u/C+MJsHuQSaUyA==
   dependencies:
     fast-glob "^3.2.7"
 
-mocha@^9.2.1:
-  version "9.2.1"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-9.2.1.tgz#a1abb675aa9a8490798503af57e8782a78f1338e"
-  integrity sha512-T7uscqjJVS46Pq1XDXyo9Uvey9gd3huT/DD9cYBb4K2Xc/vbKRPUWK067bxDQRK0yIz6Jxk73IrnimvASzBNAQ==
+mocha@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.0.0.tgz#205447d8993ec755335c4b13deba3d3a13c4def9"
+  integrity sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==
   dependencies:
     "@ungap/promise-all-settled" "1.1.2"
     ansi-colors "4.1.1"
     browser-stdout "1.3.1"
     chokidar "3.5.3"
-    debug "4.3.3"
+    debug "4.3.4"
     diff "5.0.0"
     escape-string-regexp "4.0.0"
     find-up "5.0.0"
     glob "7.2.0"
-    growl "1.10.5"
     he "1.2.0"
     js-yaml "4.1.0"
     log-symbols "4.1.0"
-    minimatch "3.0.4"
+    minimatch "5.0.1"
     ms "2.1.3"
-    nanoid "3.2.0"
+    nanoid "3.3.3"
     serialize-javascript "6.0.0"
     strip-json-comments "3.1.1"
     supports-color "8.1.1"
-    which "2.0.2"
-    workerpool "6.2.0"
+    workerpool "6.2.1"
     yargs "16.2.0"
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
@@ -2054,15 +2141,15 @@ ms@2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
-  integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
+nanoid@3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
+  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
-nanoid@^3.1.30:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.1.tgz#6347a18cac88af88f58af0b3594b723d5e99bb35"
-  integrity sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==
+nanoid@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
+  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
 
 neo-async@^2.6.2:
   version "2.6.2"
@@ -2080,6 +2167,11 @@ node-releases@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
   integrity sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
+
+node-releases@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.6.tgz#8a7088c63a55e493845683ebf3c828d8c51c5503"
+  integrity sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
@@ -2216,7 +2308,7 @@ path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6:
+path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
@@ -2243,27 +2335,27 @@ pkg-dir@^4.1.0:
   dependencies:
     find-up "^4.0.0"
 
-postcss-selector-parser@~6.0.4:
-  version "6.0.6"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz#2c5bba8174ac2f6981ab631a42ab0ee54af332ea"
-  integrity sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==
+postcss-selector-parser@~6.0.9:
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-postcss-value-parser@~4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
-  integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
+postcss-value-parser@~4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
+  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@~8.3.11:
-  version "8.3.11"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.11.tgz#c3beca7ea811cd5e1c4a3ec6d2e7599ef1f8f858"
-  integrity sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==
+postcss@~8.4.16:
+  version "8.4.16"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.16.tgz#33a1d675fac39941f5f445db0de4db2b6e01d43c"
+  integrity sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==
   dependencies:
-    nanoid "^3.1.30"
+    nanoid "^3.3.4"
     picocolors "^1.0.0"
-    source-map-js "^0.6.2"
+    source-map-js "^1.0.2"
 
 process-on-spawn@^1.0.0:
   version "1.0.0"
@@ -2296,13 +2388,14 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-regexp.prototype.flags@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz#7ef352ae8d159e758c0eadca6f8fcb4eef07be26"
-  integrity sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==
+regexp.prototype.flags@^1.4.1:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz#87cab30f80f66660181a3bb7bf5981a872b367ac"
+  integrity sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
+    functions-have-names "^1.2.2"
 
 release-zalgo@^1.0.0:
   version "1.0.0"
@@ -2326,13 +2419,14 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve@~1.20.0:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
-  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+resolve@^1.22.1, resolve@~1.22.1:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
   dependencies:
-    is-core-module "^2.2.0"
-    path-parse "^1.0.6"
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 reusify@^1.0.4:
   version "1.0.4"
@@ -2431,10 +2525,10 @@ signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.6.tgz#24e630c4b0f03fea446a2bd299e62b4a6ca8d0af"
   integrity sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ==
 
-source-map-js@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
-  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 source-map-support@~0.5.20:
   version "0.5.21"
@@ -2480,18 +2574,18 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string.prototype.matchall@^4.0.5:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz#5abb5dabc94c7b0ea2380f65ba610b3a544b15fa"
-  integrity sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==
+string.prototype.matchall@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz#8e6ecb0d8a1fb1fda470d81acecb2dba057a481d"
+  integrity sha512-f48okCX7JiwVi1NXCVWcFnZgADDC/n2vePlQ/KUCNqCikLLilQvwjMO8+BHVKvgzH0JB0J9LEPgxOGT02RoETg==
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
     get-intrinsic "^1.1.1"
-    has-symbols "^1.0.2"
+    has-symbols "^1.0.3"
     internal-slot "^1.0.3"
-    regexp.prototype.flags "^1.3.1"
+    regexp.prototype.flags "^1.4.1"
     side-channel "^1.0.4"
 
 string.prototype.trimend@^1.0.4:
@@ -2547,6 +2641,11 @@ supports-color@^7.1.0:
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
+
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 tapable@^2.1.1, tapable@^2.2.0:
   version "2.2.1"
@@ -2612,10 +2711,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@~4.2.4:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
-  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+typescript@~4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
+  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"
@@ -2626,6 +2725,14 @@ unbox-primitive@^1.0.1:
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
+
+update-browserslist-db@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz#be06a5eedd62f107b7c19eb5bcefb194411abf38"
+  integrity sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==
+  dependencies:
+    escalade "^3.1.1"
+    picocolors "^1.0.0"
 
 uri-js@^4.2.2:
   version "4.4.1"
@@ -2644,10 +2751,10 @@ uuid@^3.3.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-watchpack@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.3.1.tgz#4200d9447b401156eeca7767ee610f8809bc9d25"
-  integrity sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==
+watchpack@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
+  integrity sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
@@ -2665,34 +2772,34 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@~5.69.1:
-  version "5.69.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.69.1.tgz#8cfd92c192c6a52c99ab00529b5a0d33aa848dc5"
-  integrity sha512-+VyvOSJXZMT2V5vLzOnDuMz5GxEqLk7hKWQ56YxPW/PQRUuKimPqmEIJOx8jHYeyo65pKbapbW464mvsKbaj4A==
+webpack@~5.74.0:
+  version "5.74.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.74.0.tgz#02a5dac19a17e0bb47093f2be67c695102a55980"
+  integrity sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^0.0.51"
     "@webassemblyjs/ast" "1.11.1"
     "@webassemblyjs/wasm-edit" "1.11.1"
     "@webassemblyjs/wasm-parser" "1.11.1"
-    acorn "^8.4.1"
+    acorn "^8.7.1"
     acorn-import-assertions "^1.7.6"
     browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.8.3"
+    enhanced-resolve "^5.10.0"
     es-module-lexer "^0.9.0"
     eslint-scope "5.1.1"
     events "^3.2.0"
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.2.9"
-    json-parse-better-errors "^1.0.2"
+    json-parse-even-better-errors "^2.3.1"
     loader-runner "^4.2.0"
     mime-types "^2.1.27"
     neo-async "^2.6.2"
     schema-utils "^3.1.0"
     tapable "^2.1.1"
     terser-webpack-plugin "^5.1.3"
-    watchpack "^2.3.1"
+    watchpack "^2.4.0"
     webpack-sources "^3.2.3"
 
 which-boxed-primitive@^1.0.2:
@@ -2711,7 +2818,7 @@ which-module@^2.0.0:
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@2.0.2, which@^2.0.1:
+which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
@@ -2723,10 +2830,10 @@ wildcard@^2.0.0:
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
   integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
 
-workerpool@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.0.tgz#827d93c9ba23ee2019c3ffaff5c27fccea289e8b"
-  integrity sha512-Rsk5qQHJ9eowMH28Jwhe8HEbmdYDX4lwoMWshiCXugjtHqMD9ZbiqSDLxcsfdqsETPzVUtX5s1Z5kStiIM6l4A==
+workerpool@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
+  integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
 wrap-ansi@^6.2.0:
   version "6.2.0"


### PR DESCRIPTION
Removed `loader-utils`. The `getOptions` API [was moved](https://github.com/webpack/loader-utils/blob/a282654ddfa0a8c9c770db1adfa064e671bcf471/CHANGELOG.md#300-2021-10-20) to Webpack itself in v5, defined [here](https://webpack.js.org/api/loaders/#thisgetoptionsschema). 

The snapshots have changed slightly due to the LWC update.