### PR TITLE
Using `lwc` v3* packages breaks webpack due to @lwc/synthetic-shadow alias

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,15 +108,6 @@ module.exports = class Plugin {
         // Specify known package aliases
         alias['lwc'] = require.resolve('@lwc/engine-dom')
         alias['wire-service'] = require.resolve('@lwc/wire-service')
-        // the 'main' property for @lwc/synthetic-shadow refers to a file that
-        // simply logs an error message. This needs to be fixed up to directly
-        // specify the actual implementation, which lives under
-        // /dist/synthetic-shadow.js. Note: this depends on the internal file
-        // structure of this component, and there is a little fragile, if the
-        // module ever changes where this implementation lives.
-        alias['@lwc/synthetic-shadow'] = require.resolve(
-            '@lwc/synthetic-shadow/dist/synthetic-shadow.js'
-        )
 
         if (compiler.options.resolve.extensions) {
             compiler.options.resolve.extensions.push(...EXTENSIONS)

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,21 @@ module.exports = class Plugin {
         alias['lwc'] = require.resolve('@lwc/engine-dom')
         alias['wire-service'] = require.resolve('@lwc/wire-service')
 
+        try {
+            // the 'main' property for @lwc/synthetic-shadow refers to a file that
+            // simply logs an error message. This needs to be fixed up to directly
+            // specify the actual implementation, which lives under
+            // /dist/synthetic-shadow.js. Note: this depends on the internal file
+            // structure of this component, and there is a little fragile, if the
+            // module ever changes where this implementation lives.
+            alias['@lwc/synthetic-shadow'] = require.resolve(
+                '@lwc/synthetic-shadow/dist/synthetic-shadow.js'
+            )
+        } catch (error) {
+            // v3 LWC packages do not require the synthetic-shadow resolution
+        }
+        
+
         if (compiler.options.resolve.extensions) {
             compiler.options.resolve.extensions.push(...EXTENSIONS)
         } else {


### PR DESCRIPTION
attempting to run webpack with the new LWC v3 package versions (released as part of https://github.com/salesforce/lwc/pull/3600).

this throws an error of:

```
[webpack-cli] Error: Cannot find module '@lwc/synthetic-shadow/dist/synthetic-shadow.js'
```

Removing the alias gets webpack working again.
