### PR TITLE
feat: added enableDynamicComponents option for Webpack

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,8 @@ interface PluginConfig {
     modules: any[]
     stylesheetConfig: any
     outputConfig: any
-    experimentalDynamicComponent: any
+    experimentalDynamicComponent: any,
+    enableDynamicComponents: Boolean
 }
 
 const PACKAGE_JSON = 'package.json'
@@ -86,7 +87,8 @@ module.exports = class Plugin {
             modules = [],
             stylesheetConfig,
             outputConfig = {},
-            experimentalDynamicComponent = {}
+            experimentalDynamicComponent = {},
+            enableDynamicComponents
         } = this.config || {}
         compiler.hooks.environment.tap('lwc-webpack-plugin', () => {
             const resolverPlugin = new LwcModuleResolverPlugin(modules)
@@ -133,7 +135,8 @@ module.exports = class Plugin {
                 options: {
                     stylesheetConfig,
                     outputConfig,
-                    experimentalDynamicComponent
+                    experimentalDynamicComponent,
+                    enableDynamicComponents
                 }
             }
         })

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -10,7 +10,7 @@ const { getInfoFromPath } = require('./module')
 
 module.exports = function loader (source: any) {
     const { resourcePath, resourceQuery, getOptions } = this
-    const { stylesheetConfig, outputConfig, experimentalDynamicComponent } = getOptions()
+    const { stylesheetConfig, outputConfig, experimentalDynamicComponent, enableDynamicComponents } = getOptions()
 
     let info
     try {
@@ -35,6 +35,7 @@ module.exports = function loader (source: any) {
         stylesheetConfig,
         outputConfig,
         experimentalDynamicComponent,
+        enableDynamicComponents,
         scopedStyles
     };
     // Avoid passing stylesheetConfig when undefined to avoid deprecation warning (lwc v3.1.3)


### PR DESCRIPTION
I noticed that the **lwc-webpack-plugin** only passes specific set of options to the @lwc/compiler, and it seems to be missing the _enableDynamicComponents_ one which prevents users of the plugin to use dynamic imports with their LWCs.

