### PR TITLE
test: make snapshot tests resilient to apiVersion changes

### DIFF
--- a/test/__snapshots__/basic-test/component-with-HTML-CSS-and-JS.expected.txt
+++ b/test/__snapshots__/basic-test/component-with-HTML-CSS-and-JS.expected.txt
@@ -194,7 +194,7 @@ __webpack_require__.r(__webpack_exports__);
 }), {
   tmpl: _component_html__WEBPACK_IMPORTED_MODULE_1__["default"],
   sel: "x-component",
-  apiVersion: 61
+  apiVersion: XXX
 }));
 })();
 

--- a/test/__snapshots__/basic-test/component-with-implicit-CSS.expected.txt
+++ b/test/__snapshots__/basic-test/component-with-implicit-CSS.expected.txt
@@ -182,7 +182,7 @@ __webpack_require__.r(__webpack_exports__);
 }, {
   tmpl: _component_html__WEBPACK_IMPORTED_MODULE_0__["default"],
   sel: "x-component",
-  apiVersion: 61
+  apiVersion: XXX
 }));
 })();
 

--- a/test/__snapshots__/basic-test/component-with-implicit-HTML.expected.txt
+++ b/test/__snapshots__/basic-test/component-with-implicit-HTML.expected.txt
@@ -122,7 +122,7 @@ __webpack_require__.r(__webpack_exports__);
 }, {
   tmpl: _component_html__WEBPACK_IMPORTED_MODULE_0__["default"],
   sel: "x-component",
-  apiVersion: 61
+  apiVersion: XXX
 }));
 })();
 

--- a/test/__snapshots__/basic-test/component-with-missing-css.expected.txt
+++ b/test/__snapshots__/basic-test/component-with-missing-css.expected.txt
@@ -121,7 +121,7 @@ var _class;
 }, _class.stylesheets = [_component_html__WEBPACK_IMPORTED_MODULE_0__["default"]], _class), {
   tmpl: _component_html__WEBPACK_IMPORTED_MODULE_0__["default"],
   sel: "x-component",
-  apiVersion: 61
+  apiVersion: XXX
 }));
 })();
 

--- a/test/__snapshots__/basic-test/component-with-multiple-templates.expected.txt
+++ b/test/__snapshots__/basic-test/component-with-multiple-templates.expected.txt
@@ -266,7 +266,7 @@ __webpack_require__.r(__webpack_exports__);
 }), {
   tmpl: _component_html__WEBPACK_IMPORTED_MODULE_1__["default"],
   sel: "x-component",
-  apiVersion: 61
+  apiVersion: XXX
 }));
 })();
 

--- a/test/__snapshots__/basic-test/component-with-scoped-CSS.expected.txt
+++ b/test/__snapshots__/basic-test/component-with-scoped-CSS.expected.txt
@@ -185,7 +185,7 @@ __webpack_require__.r(__webpack_exports__);
 }, {
   tmpl: _component_html__WEBPACK_IMPORTED_MODULE_0__["default"],
   sel: "x-component",
-  apiVersion: 61
+  apiVersion: XXX
 }));
 })();
 

--- a/test/__snapshots__/basic-test/component-with-typescript.expected.txt
+++ b/test/__snapshots__/basic-test/component-with-typescript.expected.txt
@@ -194,7 +194,7 @@ __webpack_require__.r(__webpack_exports__);
 }), {
   tmpl: _component_html__WEBPACK_IMPORTED_MODULE_1__["default"],
   sel: "x-component",
-  apiVersion: 61
+  apiVersion: XXX
 }));
 })();
 

--- a/test/__snapshots__/config-test/lwc-config-json/basic-component-using-lwc-config-json.expected.txt
+++ b/test/__snapshots__/config-test/lwc-config-json/basic-component-using-lwc-config-json.expected.txt
@@ -194,7 +194,7 @@ __webpack_require__.r(__webpack_exports__);
 }), {
   tmpl: _component_html__WEBPACK_IMPORTED_MODULE_1__["default"],
   sel: "x-component",
-  apiVersion: 61
+  apiVersion: XXX
 }));
 })();
 

--- a/test/__snapshots__/config-test/lwc-key-in-package-json/basic-component-using-lwc-config-json.expected.txt
+++ b/test/__snapshots__/config-test/lwc-key-in-package-json/basic-component-using-lwc-config-json.expected.txt
@@ -194,7 +194,7 @@ __webpack_require__.r(__webpack_exports__);
 }), {
   tmpl: _component_html__WEBPACK_IMPORTED_MODULE_1__["default"],
   sel: "x-component",
-  apiVersion: 61
+  apiVersion: XXX
 }));
 })();
 

--- a/test/__snapshots__/modules-configuration-test/external-npm-package/works-with-an-external-lib-using-the-npm-key.expected.txt
+++ b/test/__snapshots__/modules-configuration-test/external-npm-package/works-with-an-external-lib-using-the-npm-key.expected.txt
@@ -66,7 +66,7 @@ __webpack_require__.r(__webpack_exports__);
 }, {
   tmpl: _component_html__WEBPACK_IMPORTED_MODULE_0__["default"],
   sel: "y-component",
-  apiVersion: 61
+  apiVersion: XXX
 }));
 ;
 
@@ -256,7 +256,7 @@ __webpack_require__.r(__webpack_exports__);
 }, {
   tmpl: _component_html__WEBPACK_IMPORTED_MODULE_0__["default"],
   sel: "x-component",
-  apiVersion: 61
+  apiVersion: XXX
 }));
 })();
 

--- a/test/__snapshots__/modules-configuration-test/works-with-modules-defined-with-the-alias-key.expected.txt
+++ b/test/__snapshots__/modules-configuration-test/works-with-modules-defined-with-the-alias-key.expected.txt
@@ -194,7 +194,7 @@ __webpack_require__.r(__webpack_exports__);
 }), {
   tmpl: _component_html__WEBPACK_IMPORTED_MODULE_1__["default"],
   sel: "x-component",
-  apiVersion: 61
+  apiVersion: XXX
 }));
 })();
 

--- a/test/utils.mjs
+++ b/test/utils.mjs
@@ -66,7 +66,8 @@ async function testSnapshot(code) {
     // Replace LWC versions in the source code comments so that the snapshots don't change so frequently
     code = code
       .replace(/\/\*\* version: \d+\.\d+\.\d+ \*\//g, '/** version: X.X.X */')
-      .replace(/\/\*LWC compiler v\d+\.\d+\.\d+\*\//g, '/*LWC compiler vX.X.X*/');
+      .replace(/\/\*LWC compiler v\d+\.\d+\.\d+\*\//g, '/*LWC compiler vX.X.X*/')
+      .replace(/apiVersion: \d+/g, 'apiVersion: XXX');
     await snap(code)
 }
 


### PR DESCRIPTION
These snapshots don't need to break every time LWC bumps the API version.